### PR TITLE
Fb organic groups context

### DIFF
--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -15,22 +15,16 @@ use Drupal\DrupalExtension\Context\RawDrupalContext;
 class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
-   * Subscribe user to group with specific role.
-   * 
+   * Subscribe user to group.
+   *
    * @param string $group_type
    *   Entity type which user is subcript.
    * @param int $gid
-   *   Group id
-   * @param string $role
-   *   Role.
+   *   Group id.
    * @param object $user
-   *   User.
-   * 
+   *   User being subscript.
    */
-  public function assertUserBelongsToGroupWithRole($group_type, $gid, $role, $user)
-  {
-    $entities = entity_load($group_type, array($gid));
-    $entity = reset($entities);
+  public function subscribeUserToGroup($group_type, $gid, $user) {
     $membership = og_group($group_type, $gid, array(
       "entity type" => 'user',
       "entity" => $user,
@@ -39,10 +33,32 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
     if (!$membership) {
       throw new \Exception("The Organic Group membership could not be created.");
     }
+  }
+  
+  /**
+   * Subscribe user to group with specific role.
+   *
+   * @param string $group_type
+   *   Entity type which user is subcript.
+   * @param int $gid
+   *   Group id.
+   * @param string $role
+   *   Role.
+   * @param object $user
+   *   User being subscript.
+   */
+  public function subscribeUserToGroupWithRole($group_type, $gid, $role, $user)
+  {
+    // Subscript user to group.
+    $this->subscribeUserToGroup($group_type, $gid, $user);
+
+    // Load og entity.
+    $entities = entity_load($group_type, array($gid));
+    $entity = reset($entities);
 
     $og_roles = og_roles($group_type, $entity->type, $gid, FALSE, FALSE);
     $rid = array_search($role, $og_roles);
-    
+
     if (!$rid) {
       throw new \Exception("'$role' is not a valid group role.");
     }

--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -59,7 +59,7 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
    * @param string $group_name
    *   Group name.
    *
-   * @Given user :user is subscribed to :group_type group with name :name
+   * @Given user :user is subscribed to the group of type :group_type group with name :name
    */
   public function userIsSubscribedToGroup($username, $group_type, $group_name) {
     $gid = $this->getEntityIdBylabel($group_type, $group_name);
@@ -80,7 +80,7 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
    * @param string $group_name
    *   Group name.
    *
-   * @Given user :user is subscribed to :group_type group with name :name as a :role role(s)
+   * @Given user :user is subscribed to the group of type :group_type group with name :name as a(n) :role role(s)
    */
   public function userIsSubscribedToGroupWithRoles($username, $group_type, $group_name, $roles) {
     $gid = $this->getEntityIdBylabel($group_type, $group_name);

--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -1,10 +1,8 @@
 <?php
-
 /**
  * @file
  *
- * DrupalUtilsContext Context for Behat.
- *
+ * Context for Behat which contains utilities for Organic groups.
  */
 
 namespace Metadrop\Behat\Context;
@@ -12,6 +10,9 @@ namespace Metadrop\Behat\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 
+/**
+ * Utilities for testing organic groups.
+ */
 class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**

--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -98,6 +98,36 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
   }
 
   /**
+   * Subscribes user to group (node).
+   *
+   * @param string $username
+   *   User name.
+   * @param string $group_name
+   *   Group name.
+   *
+   * @Given user :user is subscribed to the group with name :name
+   */
+  public function userIsSubscribedToNodeGroup($username, $group_name) {
+    $this->userIsSubscribedToGroup($username, 'node', $group_name);
+  }
+
+  /**
+   * Subscribes user to group (node) with specific roles.
+   *
+   * @param string $username
+   *   User name.
+   * @param string $group_name
+   *   Group name.
+   * @param string $roles
+   *   Roles. Use ',' to add multiple.
+   *
+   * @Given user :user is subscribed to the group with name :name as a(n) :role role(s)
+   */
+  public function userIsSubscribedToNodeGroupWithRoles($username, $group_name, $roles) {
+    $this->userIsSubscribedToGroupWithRoles($username, 'node', $group_name, $roles);
+  }
+
+  /**
    * Subscribe user to group.
    *
    * @param string $group_type

--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file
+ *
+ * DrupalUtilsContext Context for Behat.
+ *
+ */
+
+namespace Metadrop\Behat\Context;
+
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements SnippetAcceptingContext {
+
+  /**
+   * Subscribe user to group with specific role.
+   * 
+   * @param string $group_type
+   *   Entity type which user is subcript.
+   * @param int $gid
+   *   Group id
+   * @param string $role
+   *   Role.
+   * @param object $user
+   *   User.
+   * 
+   */
+  public function assertUserBelongsToGroupWithRole($group_type, $gid, $role, $user)
+  {
+    $entities = entity_load($group_type, array($gid));
+    $entity = reset($entities);
+    $membership = og_group($group_type, $gid, array(
+      "entity type" => 'user',
+      "entity" => $user,
+    ));
+
+    if (!$membership) {
+      throw new \Exception("The Organic Group membership could not be created.");
+    }
+
+    $og_roles = og_roles($group_type, $entity->type, $gid, FALSE, FALSE);
+    $rid = array_search($role, $og_roles);
+    
+    if (!$rid) {
+      throw new \Exception("'$role' is not a valid group role.");
+    }
+
+    og_role_grant($group_type, $gid, $user->uid, $rid);
+  }
+}

--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -16,6 +16,88 @@ use Drupal\DrupalExtension\Context\RawDrupalContext;
 class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
+   * Get entity id by entity label.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param string $label
+   *   Label.
+   *
+   * @return int
+   *   Entity id.
+   */
+  public function getEntityIdBylabel($entity_type, $label) {
+    $entity_info = entity_get_info($entity_type);
+
+    // Add label key to user entity.
+    // this is done by drupaldriver for some similar purpose.
+    // @see Drupal\Driver\Fields\Drupal7\EntityReferenceHandler::expand()
+    if ($entity_type == 'user') {
+      $entity_info['entity keys']['label'] = 'name';
+    }
+    if (!empty($entity_info['entity keys']['label'])) {
+      $entity_id = db_select($entity_info['base table'], 'entity')
+        ->fields('entity', [$entity_info['entity keys']['id']])
+        ->condition($entity_info['entity keys']['label'], $label)
+        ->execute()
+        ->fetchField();
+    }
+    else {
+      $entity_id = NULL;
+    }
+
+    return $entity_id;
+  }
+
+  /**
+   * Subscribes user to group
+   *
+   * @param string $username
+   *   User name.
+   * @param string $group_type
+   *   Group type.
+   * @param string $group_name
+   *   Group name.
+   *
+   * @Given user :user is subscribed to :group_type group with name :name
+   */
+  public function userIsSubscribedToGroup($username, $group_type, $group_name) {
+    $gid = $this->getEntityIdBylabel($group_type, $group_name);
+    if (empty($gid)) {
+      throw new Exception($group_type . ' group with name ' . $group_name . ' doesn\'t exists!');
+    }
+    $user = user_load_by_name($username);
+    $this->subscribeUserToGroup($group_type, $gid, $user);
+  }
+
+  /**
+   * Subscribes user to group
+   *
+   * @param string $username
+   *   User name.
+   * @param string $group_type
+   *   Group type.
+   * @param string $group_name
+   *   Group name.
+   *
+   * @Given user :user is subscribed to :group_type group with name :name as a :role role(s)
+   */
+  public function userIsSubscribedToGroupWithRoles($username, $group_type, $group_name, $roles) {
+    $gid = $this->getEntityIdBylabel($group_type, $group_name);
+    if (empty($gid)) {
+      throw new Exception($group_type . ' group with name ' . $group_name . ' doesn\'t exists!');
+    }
+
+    $user = user_load_by_name($username);
+    $this->subscribeUserToGroup($group_type, $gid, $user);
+
+    $roles_array = explode(',', $roles);
+    foreach ($roles_array as $role) {
+      $this->addUserGroupRole($group_type, $gid, $role, $user);
+    }
+  }
+
+  /**
    * Subscribe user to group.
    *
    * @param string $group_type
@@ -35,7 +117,7 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
       throw new \Exception("The Organic Group membership could not be created.");
     }
   }
-  
+
   /**
    * Subscribe user to group with specific role.
    *
@@ -54,6 +136,25 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
     $this->subscribeUserToGroup($group_type, $gid, $user);
 
     // Load og entity.
+    $this->subscribeUserToGroupWithRole($group_type, $gid, $role, $user);
+  }
+
+  /**
+   * Add user role on specific group.
+   *
+   * @param string $group_type
+   *   Group entity type. For example, "node".
+   * @param int $gid
+   *   Group entity id.
+   * @param string $role
+   *   Group role.
+   * @param object $user
+   *   user.
+   *
+   * @throws \Exception
+   *   When role doesn't exists.
+   */
+  public function addUserGroupRole($group_type, $gid, $role, $user) {
     $entities = entity_load($group_type, array($gid));
     $entity = reset($entities);
 
@@ -66,4 +167,5 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
 
     og_role_grant($group_type, $gid, $user->uid, $rid);
   }
+
 }

--- a/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -59,7 +59,7 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
    * @param string $group_name
    *   Group name.
    *
-   * @Given user :user is subscribed to the group of type :group_type group with name :name
+   * @Given user :user is subscribed to the group of type :group_type with name :name
    */
   public function userIsSubscribedToGroup($username, $group_type, $group_name) {
     $gid = $this->getEntityIdBylabel($group_type, $group_name);
@@ -80,7 +80,7 @@ class DrupalOrganicGroupsExtendedContext extends RawDrupalContext implements Sni
    * @param string $group_name
    *   Group name.
    *
-   * @Given user :user is subscribed to the group of type :group_type group with name :name as a(n) :role role(s)
+   * @Given user :user is subscribed to the group of type :group_type with name :name as a(n) :role role(s)
    */
   public function userIsSubscribedToGroupWithRoles($username, $group_type, $group_name, $roles) {
     $gid = $this->getEntityIdBylabel($group_type, $group_name);


### PR DESCRIPTION
Hello.

I was using this library to make tests in my Drupal projects.
I needed make steps in order to subscribe user in a organic group. 
So I created a branch with a context which provides methods (no steps) to subscribe user to groups, easy to implement in steps. 

There are 2 methods: one subscribes user in a group, and the other subscribes user and give specific group role.

Can you review this, and merge if you like? Thanks!
