### PR TITLE
New step: fileFieldIsNotMultiple

### DIFF
--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -50,4 +50,31 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
                    jQuery('#$id').trigger('change');";
     $this->getSession()->executeScript($javascript);
   }
+
+  /**
+   * Step to remove the multiple property of a file field.
+   *
+   * PhantomJS is not compatible with file field multiple and crashes.
+   * This workarround removes the property, that way the test can upload at least
+   * one file to the widget.
+   *
+   * @Given the file field :field is not multiple
+   */
+  public function fileFieldIsNotMultiple($locator) {
+    $el = $this->getSession()->getPage()->findField($locator);
+
+    if (empty($el)) {
+      throw new ExpectationException('Could not find element with locator: ' . $locator, $this->getSession());
+    }
+
+    $fieldId = $el->getAttribute('id');
+
+    if (empty($fieldId)) {
+      throw new Exception('Could not find an id for field with locator: ' . $locator);
+    }
+
+    $this->getSession()
+      ->executeScript("jQuery('#$fieldId').removeAttr('multiple');");
+  }
+
 }

--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -55,7 +55,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
    * Step to remove the multiple property of a file field.
    *
    * PhantomJS is not compatible with file field multiple and crashes.
-   * This workarround removes the property, this way the test can upload at least
+   * This workaround removes the property, this way the test can upload at least
    * one file to the widget.
    *
    * @Given the file field :field is not multiple
@@ -68,7 +68,6 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
     }
 
     $fieldId = $el->getAttribute('id');
-
     if (empty($fieldId)) {
       throw new Exception('Could not find an id for field with locator: ' . $locator);
     }

--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -55,7 +55,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
    * Step to remove the multiple property of a file field.
    *
    * PhantomJS is not compatible with file field multiple and crashes.
-   * This workarround removes the property, that way the test can upload at least
+   * This workarround removes the property, this way the test can upload at least
    * one file to the widget.
    *
    * @Given the file field :field is not multiple


### PR DESCRIPTION
PhantomJS is not compatible with file field multiple and crashes.
This workarround removes the property, this way the test can upload at least one file to the widget.