### PR TITLE
userShouldHaveTheRole: case insensitive

### DIFF
--- a/Behat/Context/DrupalExtendedContext.php
+++ b/Behat/Context/DrupalExtendedContext.php
@@ -155,11 +155,14 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
     if ($account) {
       $roles = explode(',', $role);
       $roles = array_map('trim', $roles);
+      // Case insensitive:
+      $roles = array_map('strtolower', $roles);
+      $aroles = array_map('strtolower', $account->roles);
       foreach ($roles as $role) {
-        if (!$not && !in_array($role, $account->roles)) {
+        if (!$not && !in_array($role, $aroles)) {
           throw new \Exception("Given user does not have the role $role");
         }
-        else if ($not && in_array($role, $account->roles)) {
+        else if ($not && in_array($role, $aroles)) {
           throw new \Exception("Given user have the role $role");
         }
       }


### PR DESCRIPTION
Comparation should be case insensitive as drupal does not let you create two role names like: "Member" and "member".

This path helps with false possitive: "the user does not have the role Member", and the user does have the role "member" (which should be the same) 