### PR TITLE
New step: wait for ajax specifying time to wait.

### DIFF
--- a/Behat/Context/DrupalExtendedContext.php
+++ b/Behat/Context/DrupalExtendedContext.php
@@ -338,7 +338,13 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
   /**
    * Wait for AJAX to finish.
    *
+   * @param int $seconds
+   *   Max time to wait for AJAX.
+   *
    * @Given I wait for AJAX to finish almost :seconds seconds
+   *
+   * @throws \Exception
+   *   Ajax call didn't finish.
    */
   public function iWaitForAjaxToFinish($seconds) {
     $finished = $this->getSession()->wait($seconds * 1000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');

--- a/Behat/Context/DrupalExtendedContext.php
+++ b/Behat/Context/DrupalExtendedContext.php
@@ -334,4 +334,17 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
       $this->nodeCreate($node);
     }
   }
+
+  /**
+   * Wait for AJAX to finish.
+   *
+   * @Given I wait for AJAX to finish almost :seconds seconds
+   */
+  public function iWaitForAjaxToFinish($seconds) {
+    $finished = $this->getSession()->wait($seconds * 1000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
+    if (!$finished) {
+      throw new \Exception("Ajax call didn't finished within $seconds seconds.");
+    }
+  }
+
 }

--- a/Behat/Context/DrupalExtendedContext.php
+++ b/Behat/Context/DrupalExtendedContext.php
@@ -341,10 +341,10 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
    * @param int $seconds
    *   Max time to wait for AJAX.
    *
-   * @Given I wait for AJAX to finish almost :seconds seconds
+   * @Given I wait for AJAX to finish at least :seconds seconds
    *
    * @throws \Exception
-   *   Ajax call didn't finish.
+   *   Ajax call didn't finish on time.
    */
   public function iWaitForAjaxToFinish($seconds) {
     $finished = $this->getSession()->wait($seconds * 1000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');


### PR DESCRIPTION
Hi.

I made a new step. It's the same step than 'I wait for AJAX to finish' from drupal extension but you can specify the time to wait. In addition, if time to wait is excedded and AJAX didn't finish, throw the Exception.

By this way we can set a correct time for each specific request, and mark test as failed when AJAX call didn't completed, instead of show a error in the next steps.

Can you review and merge this? Thanks!