### PR TITLE
BUGFIX: captureFullPageWithWidthOfToWithName expects number

### DIFF
--- a/Behat/Context/DebugContext.php
+++ b/Behat/Context/DebugContext.php
@@ -274,7 +274,7 @@ class DebugContext extends RawDrupalContext implements SnippetAcceptingContext {
    */
   public function captureFullPageWithWidthOfToWithName($width, $path, $filename) {
     // Use default height as screenshot is going to capture the complete page.
-    $this->getSession()->resizeWindow($width, $this::DEFAULT_HEIGHT, 'current');
+    $this->getSession()->resizeWindow((int) $width, $this::DEFAULT_HEIGHT, 'current');
     $this->savescreenShot($filename, $this->getScreenshotAbsolutePath($path, NULL));
   }
 


### PR DESCRIPTION
The windowResize method called by captureFullPageWithWidthOfToWithName expects a number not a string: so casting it.

   And capture full page with a width of 1200
      java.lang.String cannot be cast to java.lang.Number (WebDriver\Exception\UnknownError)


