### PR TITLE
Add namespace required to throw ExpectationException

### DIFF
--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -14,6 +14,7 @@ namespace Metadrop\Behat\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Behat\Mink\Exception\ExpectationException;
 
 class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
 


### PR DESCRIPTION
Hi. In this pull request I add namespace for ExpectationException in order to prevent this fatal error:
`PHP Fatal error:  Class 'Metadrop\Behat\Context\ExpectationException' not found`

Can you merge this? Thanks!