### PR TITLE
Added steps: click element with xpath/css + label

### DIFF
--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -156,4 +156,54 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   }
 
+  /**
+   * Click on the element with the provided CSS Selector
+   *
+   * @When /^I click on the element with css selector "([^"]*)"$/
+   */
+  public function iClickOnTheElementWithCSSSelector($cssSelector) {
+    $session = $this->getSession();
+    $element = $session->getPage()->find(
+      'xpath',
+      $session->getSelectorsHandler()->selectorToXpath('css', $cssSelector) // just changed xpath to css
+    );
+    if (null === $element) {
+      throw new \InvalidArgumentException(sprintf('Could not evaluate CSS Selector: "%s"', $cssSelector));
+    }
+
+    $element->click();
+  }
+
+  /**
+   * Click on the element with the provided xpath query
+   *
+   * @When /^I click on the element with xpath "([^"]*)"$/
+   */
+  public function iClickOnTheElementWithXPath($xpath) {
+    $session = $this->getSession(); // get the mink session
+    $element = $session->getPage()->find(
+      'xpath',
+      $session->getSelectorsHandler()->selectorToXpath('xpath', $xpath)
+    );
+
+    // errors must not pass silently
+    if (null === $element) {
+      throw new \InvalidArgumentException(sprintf('Could not evaluate XPath: "%s"', $xpath));
+    }
+
+    // ok, let's click on it
+    $element->click();
+  }
+
+  /**
+   * Click on the label using xpath
+   *
+   * @When I click on the label :label
+   */
+  public function iClickOnTheLabel($label) {
+    $label = str_replace("\"", "\\\"", $label);
+    $xpath = '//label[text()="' . $label . '"]';
+    $this->iClickOnTheElementWithXPath($xpath);
+  }
+
 }

--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -198,7 +198,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
   /**
    * Click on the label using xpath.
    *
-   * @When I click on the label :label
+   * @When I click on the :label label
    */
   public function iClickOnTheLabel($label) {
     $label = str_replace("\"", "\\\"", $label);

--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -157,7 +157,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
   }
 
   /**
-   * Click on the element with the provided CSS Selector
+   * Click on the element with the provided CSS Selector.
    *
    * @When /^I click on the element with css selector "([^"]*)"$/
    */
@@ -175,7 +175,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
   }
 
   /**
-   * Click on the element with the provided xpath query
+   * Click on the element with the provided xpath query.
    *
    * @When /^I click on the element with xpath "([^"]*)"$/
    */
@@ -196,7 +196,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
   }
 
   /**
-   * Click on the label using xpath
+   * Click on the label using xpath.
    *
    * @When I click on the label :label
    */


### PR DESCRIPTION
Hi I've added to steps to click on an element with CSS and XPath. Also a shortcut for labels.

When you use Chrome (Chromedriver) if the radiobuttons/checkboxes are themed in a special way (they are hidden and some tricky css are replacing them) is common to see the message:

```
When I select the radio button “Militaire”
      unknown error: Element <input data-drupal-selector=“edit-status-militaire” type=“radio” id=“edit-status-militaire” name=“status” value=“militaire” class=“form-radio”> is not clickable at point (336, 271). Other element would receive the click: <div class=“js-form-item form-item js-form-type-radio form-type-radio js-form-item-status form-item-status”>...</div>
```
So we need a step to click directly on the label which is been shown.
In this commit, there are a global CSS/XPath steps forked from http://masnun.com/2012/11/28/behat-and-mink-finding-and-clicking-with-xpath-and-jquery-like-css-selector.html (thank you!) and a specific one for labels without needed to think in xpath selectors (based on label text() ).

Please review!
