### PR TITLE
Quickest scroll: scrollToSelector ZERO latency

### DIFF
--- a/Behat/Context/UIContext.php
+++ b/Behat/Context/UIContext.php
@@ -123,7 +123,7 @@ class UIContext extends RawDrupalContext implements SnippetAcceptingContext {
     $offset_default = isset($this->customParams['scroll_offset']) ? $this->customParams['scroll_offset'] : 0;
     $offset = is_null($offset) ? $offset_default : $offset;
     $op = $offset >= 0 ? '+' : '-';
-    $script = "jQuery('html,body').unbind().animate({scrollTop: jQuery('$selector').offset().top" . $op . abs($offset) . "},'slow')";
+    $script = "jQuery('html,body').unbind().animate({scrollTop: jQuery('$selector').offset().top" . $op . abs($offset) . "},0)";
     $this->getSession()->executeScript($script);
   }
 


### PR DESCRIPTION
We use the scroll when we need to move to a specific part of the page, it does not need to be realistic and it needs to be as fast as possible to avoid using "and I wait X seconds" after each step.

Attaching patch applying ZERO latency to the scroll step.

please review