### PR TITLE
Correctly name protected variable customParams to customParameters.

### DIFF
--- a/Behat/Context/DebugContext.php
+++ b/Behat/Context/DebugContext.php
@@ -56,7 +56,7 @@ class DebugContext extends RawDrupalContext implements SnippetAcceptingContext {
    *
    * @var array
    */
-  protected $customParams;
+  protected $customParameters;
 
   /**
    * The Mink session.

--- a/Behat/Context/DebugContext.php
+++ b/Behat/Context/DebugContext.php
@@ -87,6 +87,13 @@ class DebugContext extends RawDrupalContext implements SnippetAcceptingContext {
   protected $feature;
 
   /**
+   * Failed step's file name.
+   *
+   * @var completed file name error.
+   */
+  protected $filenameTemplate;
+  
+  /**
    * Constructor.
    *
    * Save class params, if any.


### PR DESCRIPTION
Version behat3.3 trigger Error Unsupported operand.