### PR TITLE
Compatibility with behat3.3: usage of $this->user

### DIFF
--- a/Behat/Context/BrowserSizeContext.php
+++ b/Behat/Context/BrowserSizeContext.php
@@ -30,7 +30,7 @@ class BrowserSizeContext extends RawDrupalContext implements SnippetAcceptingCon
    *
    * @var array
    */
-  protected $customParams;
+  protected $customParameters;
 
   /**
    * Constructor.

--- a/Behat/Context/DrupalExtendedContext.php
+++ b/Behat/Context/DrupalExtendedContext.php
@@ -163,7 +163,7 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
    */
   public function userRoleCheck($role, $user = NULL, $not = FALSE) {
     if (empty($user)) {
-      $account = $this->user;
+      $account = $this->getUserManager()->getCurrentUser();
     }
     else {
       $condition = $this->getUserPropertyByName($user);
@@ -337,7 +337,7 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
     foreach ($nodesTable->getHash() as $nodeHash) {
       $node = (object) $nodeHash;
       $node->type = $type;
-      $node->uid  = $this->user->uid;
+      $node->uid  = $this->getUserManager->getCurrentUser()->uid;
       $this->nodeCreate($node);
     }
   }

--- a/Behat/Context/DrupalExtendedContext.php
+++ b/Behat/Context/DrupalExtendedContext.php
@@ -163,7 +163,8 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
    */
   public function userRoleCheck($role, $user = NULL, $not = FALSE) {
     if (empty($user)) {
-      $account = $this->getUserManager()->getCurrentUser();
+      $current_user = $this->getUserManager()->getCurrentUser();
+      $account = user_load($current_user->uid);
     }
     else {
       $condition = $this->getUserPropertyByName($user);
@@ -337,7 +338,7 @@ class DrupalExtendedContext extends RawDrupalContext implements SnippetAccepting
     foreach ($nodesTable->getHash() as $nodeHash) {
       $node = (object) $nodeHash;
       $node->type = $type;
-      $node->uid  = $this->getUserManager->getCurrentUser()->uid;
+      $node->uid  = $this->getUserManager()->getCurrentUser()->uid;
       $this->nodeCreate($node);
     }
   }


### PR DESCRIPTION
Hi.
In new versions of behat (behat3.3-dev)  $this->user can't be used directly, it should be used $this->getUserManager() methods instead.
This PR fix the usage of $this->user in all parts of code is being used:
- Steps to check user role
- Given own content step

This force to use behat3.3 version, we may make a fallback for previous versions?