### PR TITLE
Added custom step to check entity values.

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -2,6 +2,11 @@
 
 namespace Metadrop\Behat\Context;
 
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Class EntityContext.
+ */
 class EntityContext extends RawDrupalContext {
 
   /**
@@ -13,13 +18,6 @@ class EntityContext extends RawDrupalContext {
    * @Given I go to :subpath of the last entity :entity with :bundle bundle created
    *
    * @USECORE
-   *
-   * @param string $entity_type
-   *   Entity type.
-   * @param string $bundle
-   *   Entity bundle.
-   * @param string $subpath
-   *   Entity bundle.
    */
   public function goToTheLastEntityCreated($entity_type, $bundle = NULL, $subpath = NULL) {
     $last_entity = $this->getCore()->getLastEntityId($entity_type, $bundle);
@@ -35,4 +33,101 @@ class EntityContext extends RawDrupalContext {
     }
   }
 
+  /**
+   * Check entity fields.
+   *
+   * @Then the :entity_type with field :field_name and value :value should not have the following values:
+   */
+  public function checkDonotHaveValues($entity_type, $field_name, $value, TableNode $values) {
+    $this->checkEntityTestValues($entity_type, $field_name, $value, $values, FALSE);
+  }
+
+  /**
+   * Check object fields.
+   *
+   * @Then the :object_type with field :field_name and value :value should have the following values:
+   *
+   * Example:
+   * And the 'user' with field 'mail' and value 'behat@metadrop.net' should have the following values:
+   *  | mail                | uid                                                  |
+   *  | behat@metadrop.net  | entity-replacement:user:mail:behat@metadrop.net:uid |
+   */
+  public function checkEntityTestValues($entity_type, $field_name, $value, TableNode $values, $throw_error_on_empty = TRUE) {
+    $hash = $values->getHash();
+    $fields = $hash[0];
+
+    $entity = $this->getCore()->getEntityByField($entity_type, $field_name, $value);
+
+    // Check entity.
+    if (isset($entity)) {
+      throw new \Exception('The ' . $entity_type . ' with ' . $field_name . ':  ' . $value . ' not found.');
+    }
+
+    // Make field tokens replacements.
+    $fields = $this->replaceTokens($fields);
+
+    // Check entity values and obtain the errors.
+    $errors = $this->checkEntityValues($entity, $fields);
+
+    if ($throw_error_on_empty && !empty($errors)) {
+      throw new \Exception('Failed checking values: ' . implode(', ', $errors));
+    }
+    elseif (!$throw_error_on_empty && empty($errors)) {
+      throw new \Exception('Entity values are correct, but it should not!');
+    }
+  }
+
+  protected function checkEntityValues($entity, $fields) {
+    $errors = [];
+    foreach ($fields as $field => $value) {
+      $entity_value = $this->getCore()->getEntityFieldValue($field, $entity);
+      if (is_string($value) && is_string($entity_value)) {
+        $entity_value = mb_strtolower($entity_value);
+        $entity_value = strip_tags($entity_value);
+        $entity_value = preg_replace("/\r|\n/", "", $entity_value);
+        if (mb_strtolower($value) != $entity_value) {
+          $errors[] = ' - Field ' . $field . ': Expected "' . $value . '"; Got "' . $entity_value . '"';
+        }
+      }
+      if (is_array($entity_value) && !in_array($value, $entity_value)) {
+        $errors[] = ' - Field ' . $field . ': Expected "' . $value . '"; Got "' . print_r($entity_value, TRUE) . '"';
+      }
+      if (empty($entity_value) && !empty($value)) {
+        $errors[] = ' - Field ' . $field . ': Expected "' . $value . '"; Got empty.';
+      }
+    }
+    return $errors;
+  }
+
+  /**
+   *  Replacement tokens.
+   *
+   * @param array|mixed $fields
+   *   Fields to replace.
+   */
+  protected function replaceTokens($values) {
+    foreach ($values as $key => $value) {
+      if (strpos($value, 'entity-replacement') === 0) {
+        $token_pieces = explode(':', $value);
+        array_shift($token_pieces);
+        $entity_type = $token_pieces[0];
+        $field_key = $token_pieces[1];
+        $field_value = $token_pieces[2];
+        $destiny_replacement = $token_pieces[3];
+
+        $keys_exists = isset($entity_type) && isset($field_key) && isset($field_value) && isset($destiny_replacement);
+
+        if (!$keys_exists || !in_array($entity_type, $entity_types)) {
+          throw new \Exception('Token or entity values are not valid!');
+        }
+
+        $entity = $this->getEntityByField($entity_type, $field_key, $value);
+        if (!empty($entity)) {
+          $values[$key] = $this->getCore()->getEntityFieldValue($field_key, $entity, $values[$key]);
+        }
+
+      }
+    }
+    return $values;
+  }
 }

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -49,7 +49,7 @@ class EntityContext extends RawDrupalContext {
    *
    * Example:
    * And the 'user' with field 'mail' and value 'behat@metadrop.net' should have the following values:
-   *  | mail                | uid                                                  |
+   *  | mail                | uid                                                 |
    *  | behat@metadrop.net  | entity-replacement:user:mail:behat@metadrop.net:uid |
    */
   public function checkEntityTestValues($entity_type, $field_name, $value, TableNode $values, $throw_error_on_empty = TRUE) {
@@ -59,10 +59,9 @@ class EntityContext extends RawDrupalContext {
     $entity = $this->getCore()->getEntityByField($entity_type, $field_name, $value);
 
     // Check entity.
-    if (isset($entity)) {
+    if (!isset($entity)) {
       throw new \Exception('The ' . $entity_type . ' with ' . $field_name . ':  ' . $value . ' not found.');
     }
-
     // Make field tokens replacements.
     $fields = $this->replaceTokens($fields);
 
@@ -106,6 +105,8 @@ class EntityContext extends RawDrupalContext {
    *   Fields to replace.
    */
   protected function replaceTokens($values) {
+     // Get entity type list.
+    $entity_types = array_keys(\Drupal::entityManager()->getDefinitions());
     foreach ($values as $key => $value) {
       if (strpos($value, 'entity-replacement') === 0) {
         $token_pieces = explode(':', $value);
@@ -120,10 +121,10 @@ class EntityContext extends RawDrupalContext {
         if (!$keys_exists || !in_array($entity_type, $entity_types)) {
           throw new \Exception('Token or entity values are not valid!');
         }
+        $entity = $this->getCore()->getEntityByField($entity_type, $field_key, $field_value);
 
-        $entity = $this->getEntityByField($entity_type, $field_key, $value);
         if (!empty($entity)) {
-          $values[$key] = $this->getCore()->getEntityFieldValue($field_key, $entity, $values[$key]);
+          $values[$key] = $this->getCore()->getEntityFieldValue($destiny_replacement, $entity, $values[$key]);
         }
 
       }

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -106,7 +106,7 @@ class EntityContext extends RawDrupalContext {
    */
   protected function replaceTokens($values) {
      // Get entity type list.
-    $entity_types = array_keys(\Drupal::entityManager()->getDefinitions());
+    $entity_types = $this->getCore()->getEntityTypes();
     foreach ($values as $key => $value) {
       if (strpos($value, 'entity-replacement') === 0) {
         $token_pieces = explode(':', $value);

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -144,4 +144,34 @@ interface CoreInterface {
    */
   public function fileDelete($fid);
 
+  /**
+   * Obtain entity by field value.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param string $field_name
+   *   Field name.
+   * @param string $value
+   *   Field value.
+   *
+   * @return \stdClass
+   *   Entity.
+   */
+  public function getEntityByField($entity_type, $field_name, $value);
+
+  /**
+   * Obtain entity value.
+   *
+   * @param string $field_name
+   *   Field name.
+   * @param \stdClass $entity
+   *   Entity.
+   * @param string $fallback
+   *   Fallback (optional).
+   *
+   * @return string
+   *   Entity field value.
+   */
+  public function getEntityFieldValue($field_name, \stdClass $entity, $fallback = NULL);
+
 }

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -174,4 +174,12 @@ interface CoreInterface {
    */
   public function getEntityFieldValue($field_name, $entity, $fallback = NULL);
 
+  /**
+   * Get entity types availables.
+   *
+   * @return array|mixed
+   *   Entity types.
+   */
+  public function getEntityTypes();
+
 }

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -164,7 +164,7 @@ interface CoreInterface {
    *
    * @param string $field_name
    *   Field name.
-   * @param \stdClass $entity
+   * @param mixed $entity
    *   Entity.
    * @param string $fallback
    *   Fallback (optional).
@@ -172,6 +172,6 @@ interface CoreInterface {
    * @return string
    *   Entity field value.
    */
-  public function getEntityFieldValue($field_name, \stdClass $entity, $fallback = NULL);
+  public function getEntityFieldValue($field_name, $entity, $fallback = NULL);
 
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -7,7 +7,7 @@ use Metadrop\Behat\Cores\Traits\UsersTrait;
 use Webmozart\Assert\Assert;
 use Metadrop\Behat\Cores\Traits\CronTrait;
 use Metadrop\Behat\Cores\Traits\FileTrait;
-
+use Behat\Behat\Tester\Exception\PendingException;
 
 class Drupal7 extends OriginalDrupal7 implements CoreInterface {
 
@@ -163,4 +163,24 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getEditableConfig($name) {
+    throw new PendingException('Pending to implement method in Drupal 7');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityByField($entity_type, $field_name, $value) {
+    throw new PendingException('Pending to implement method in Drupal 7');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityFieldValue($field_name, \stdClass $entity, $fallback = NULL) {
+    throw new PendingException('Pending to implement method in Drupal 7');
+  }
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -180,7 +180,7 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldValue($field_name, \stdClass $entity, $fallback = NULL) {
+  public function getEntityFieldValue($field_name, $entity, $fallback = NULL) {
     throw new PendingException('Pending to implement method in Drupal 7');
   }
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -183,4 +183,11 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   public function getEntityFieldValue($field_name, $entity, $fallback = NULL) {
     throw new PendingException('Pending to implement method in Drupal 7');
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityTypes() {
+    throw new PendingException('Pending to implement method in Drupal 7');
+  }
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -166,7 +166,7 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function getEntityFieldValue($field, \stdClass $entity, $fallback = NULL) {
+  public function getEntityFieldValue($field, $entity, $fallback = NULL) {
     if ($entity->hasField($field)) {
       $fallback = ($field == 'roles') ? explode(', ', $entity->get($field)->getString()) : $entity->get($field)->getString();
     }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -173,4 +173,11 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     return $fallback;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityTypes() {
+    return array_keys(\Drupal::entityManager()->getDefinitions());
+  }
+
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -10,6 +10,7 @@ use Webmozart\Assert\Assert;
 use Behat\Behat\Tester\Exception\PendingException;
 use Drupal\user\Entity\User;
 use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\Core\Entity\EntityInterface;
 
 class Drupal8 extends OriginalDrupal8 implements CoreInterface {
 
@@ -146,6 +147,30 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
    */
   public function fileDelete($fid) {
     file_delete($fid);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityByField($entity_type, $field_name, $value) {
+    $query = \Drupal::entityQuery($entity_type);
+    $query->condition($field_name, $value);
+    $entity_ids = $query->execute();
+    rsort($entity_ids);
+    $entity_id = reset($entity_ids);
+
+    $entity = \Drupal::entityTypeManager()->getStorage($entity_type)->load($entity_id);
+    return (!empty($entity) && ($entity instanceof EntityInterface)) ? $entity : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEntityFieldValue($field, \stdClass $entity, $fallback = NULL) {
+    if ($entity->hasField($field)) {
+      $fallback = ($field == 'roles') ? explode(', ', $entity->get($field)->getString()) : $entity->get($field)->getString();
+    }
+    return $fallback;
   }
 
 }


### PR DESCRIPTION
I added a custom step to check the values of a entity, an also to have a token to replace in the check.
Here is an example:
   * And entity of type 'user' with field 'mail' and value 'behat@metadrop.net' should have the following values:
   *  | mail                             | uid                                                                                  |
   *  | behat@metadrop.net  | entity-replacement:user:mail:behat@metadrop.net:uid |

This example checks the entity "user", and makes an entity query to get the entity, using the condition field mail has the value behat@metadrop.net.

Also in the Table checks the value mail, and the uid but in the uid field makes a replacement.

The replacement woks with the word entity-replacement : entity type : key field : key value
