### PR TITLE
Comment use Drupal\DrupalExtension\Context\RawDrupalContext

### DIFF
--- a/src/Behat/Context/DrupalOrganicGroupsExtendedContext.php
+++ b/src/Behat/Context/DrupalOrganicGroupsExtendedContext.php
@@ -8,7 +8,7 @@
 namespace Metadrop\Behat\Context;
 
 use Behat\Behat\Context\SnippetAcceptingContext;
-use Drupal\DrupalExtension\Context\RawDrupalContext;
+#use Drupal\DrupalExtension\Context\RawDrupalContext;
 
 /**
  * Utilities for testing organic groups.


### PR DESCRIPTION
prevent "already used class" error, as in other contexts