### PR TITLE
Provide a generic step to create entities

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -10,6 +10,8 @@ parameters:
   drupal.driver.cores.8.class: Metadrop\Behat\Cores\Drupal8
   # Class responsible to inject service container instance in all contexts.
   drupal.behat.context_initializer.service_container.class: NuvoleWeb\Drupal\DrupalExtension\Context\Initializer\ServiceContainerInitializer
+  # Hook loader.
+  drupal.context.annotation.reader.class: Metadrop\Behat\Context\Annotation\Reader
 
 services:
   drupal.behat.component.resolution:

--- a/src/Behat/Context/Annotation/Reader.php
+++ b/src/Behat/Context/Annotation/Reader.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Metadrop\Behat\Context\Annotation;
+
+use Behat\Behat\Context\Annotation\AnnotationReader;
+use Drupal\DrupalExtension\Hook\Dispatcher;
+use Metadrop\Behat\Hook\Call\AfterEntityCreate;
+use Metadrop\Behat\Hook\Call\BeforeEntityCreate;
+use ReflectionMethod;
+
+/**
+ * Annotated contexts reader.
+ *
+ * @see \Behat\Behat\Context\Loader\AnnotatedLoader
+ */
+class Reader implements AnnotationReader {
+
+  /**
+   * @var string
+   */
+  private static $regex = '/^\@(beforeentitycreate|afterentitycreate|beforenodecreate|afternodecreate|beforetermcreate|aftertermcreate|beforeusercreate|afterusercreate)(?:\s+(.+))?$/i';
+
+  /**
+   * @var string[]
+   */
+  private static $classes = array(
+    'afternodecreate' => 'Drupal\DrupalExtension\Hook\Call\AfterNodeCreate',
+    'aftertermcreate' => 'Drupal\DrupalExtension\Hook\Call\AfterTermCreate',
+    'afterusercreate' => 'Drupal\DrupalExtension\Hook\Call\AfterUserCreate',
+    'beforenodecreate' => 'Drupal\DrupalExtension\Hook\Call\BeforeNodeCreate',
+    'beforetermcreate' => 'Drupal\DrupalExtension\Hook\Call\BeforeTermCreate',
+    'beforeusercreate' => 'Drupal\DrupalExtension\Hook\Call\BeforeUserCreate',
+    'beforeentitycreate' => BeforeEntityCreate::class,
+    'afterentitycreate' => AfterEntityCreate::class,
+  );
+
+  /**
+   * {@inheritDoc}
+   */
+  public function readCallee($contextClass, ReflectionMethod $method, $docLine, $description) {
+
+    if (!preg_match(self::$regex, $docLine, $match)) {
+      return null;
+    }
+
+    $type = strtolower($match[1]);
+    $class = self::$classes[$type];
+    $pattern = isset($match[2]) ? $match[2] : null;
+    $callable = array($contextClass, $method->getName());
+
+    return new $class($pattern, $callable, $description);
+  }
+
+}

--- a/src/Behat/Context/Annotation/Reader.php
+++ b/src/Behat/Context/Annotation/Reader.php
@@ -11,6 +11,11 @@ use ReflectionMethod;
 /**
  * Annotated contexts reader.
  *
+ * This add the neccesary contexts to allow
+ * hook into entity creation phases: 
+ * - Before create the entity.
+ * - After create the entity.
+ *
  * @see \Behat\Behat\Context\Loader\AnnotatedLoader
  */
 class Reader implements AnnotationReader {

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -25,7 +25,8 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
   protected $customParameters = [];
 
   protected $entities = [];
-/**
+
+  /**
    * Constructor.
    *
    * @param array|mixed $parameters
@@ -208,7 +209,7 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
    *        parameters:
    *          'purge_entities':
    *            - user
-   *            - custom_entity
+   *            - custom_entity.
    *
    * @AfterScenario @purgeEntities
    */
@@ -224,8 +225,11 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
     }
 
   }
+
   /**
-   * @Given :arg1 entity:
+   * Create entities.
+   *
+   * @Given :entity_type entity:
    */
   public function entity($entityType, TableNode $entitiesTable) {
     foreach ($entitiesTable->getHash() as $entityHash) {
@@ -234,7 +238,14 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
     }
   }
 
-
+  /**
+   * Create an entity.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param object $entity
+   *   Entity.
+   */
   public function entityCreate($entity_type, $entity) {
     $this->dispatchHooks('BeforeEntityCreateScope', $entity, $entity_type);
     $this->parseEntityFields($entity_type, $entity);

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -241,6 +241,10 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
   /**
    * Create an entity.
    *
+   * During the entity creation, is possible to hook into before
+   * entity creation and after, using @beforeEntityCreate
+   * and @afterEntityCreate tags.
+   *
    * @param string $entity_type
    *   Entity type.
    * @param object $entity

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -24,7 +24,8 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
    */
   protected $customParameters = [];
 
-  /**
+  protected $entities = [];
+/**
    * Constructor.
    *
    * @param array|mixed $parameters
@@ -223,6 +224,27 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
     }
 
   }
+  /**
+   * @Given :arg1 entity:
+   */
+  public function entity($entityType, TableNode $entitiesTable) {
+    foreach ($entitiesTable->getHash() as $entityHash) {
+      $entity = (object) $entityHash;
+      $this->entityCreate($entityType, $entity);
+    }
+  }
 
+
+  public function entityCreate($entity_type, $entity) {
+    $this->dispatchHooks('BeforeEntityCreateScope', $entity, $entity_type);
+    $this->parseEntityFields($entity_type, $entity);
+    $saved = \Drupal::entityTypeManager()
+      ->getStorage($entity_type)
+      ->create((array) $entity)
+      ->save();
+    $this->dispatchHooks('AfterEntityCreateScope', $entity, $entity_type);
+    $this->entities[] = $saved;
+    return $saved;
+  }
 
 }

--- a/src/Behat/Hook/Call/AfterEntityCreate.php
+++ b/src/Behat/Hook/Call/AfterEntityCreate.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Metadrop\Behat\Hook\Call;
+
+use Drupal\DrupalExtension\Hook\Call\EntityHook;
+use Drupal\DrupalExtension\Hook\Scope\EntityScope;
+
+class AfterEntityCreate extends EntityHook
+{
+
+  /**
+   * Initializes hook.
+   */
+  public function __construct($filterString, $callable, $description = null) {
+    parent::__construct(EntityScope::AFTER, $filterString, $callable, $description);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'AfterEntityCreate';
+  }
+
+}

--- a/src/Behat/Hook/Call/AfterEntityCreate.php
+++ b/src/Behat/Hook/Call/AfterEntityCreate.php
@@ -1,18 +1,19 @@
 <?php
 
-
 namespace Metadrop\Behat\Hook\Call;
 
 use Drupal\DrupalExtension\Hook\Call\EntityHook;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
 
-class AfterEntityCreate extends EntityHook
-{
+/**
+ * Hook after entity create.
+ */
+class AfterEntityCreate extends EntityHook {
 
   /**
    * Initializes hook.
    */
-  public function __construct($filterString, $callable, $description = null) {
+  public function __construct($filterString, $callable, $description = NULL) {
     parent::__construct(EntityScope::AFTER, $filterString, $callable, $description);
   }
 

--- a/src/Behat/Hook/Call/AfterEntityCreate.php
+++ b/src/Behat/Hook/Call/AfterEntityCreate.php
@@ -6,7 +6,7 @@ use Drupal\DrupalExtension\Hook\Call\EntityHook;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
 
 /**
- * Hook after entity create.
+ * Hook that is invoked after an entity is created.
  */
 class AfterEntityCreate extends EntityHook {
 

--- a/src/Behat/Hook/Call/BeforeEntityCreate.php
+++ b/src/Behat/Hook/Call/BeforeEntityCreate.php
@@ -6,7 +6,7 @@ use Drupal\DrupalExtension\Hook\Call\EntityHook;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
 
 /**
- * Hook before entity create.
+ * Hook that is invoked before an entity is created.
  */
 class BeforeEntityCreate extends EntityHook {
 

--- a/src/Behat/Hook/Call/BeforeEntityCreate.php
+++ b/src/Behat/Hook/Call/BeforeEntityCreate.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Metadrop\Behat\Hook\Call;
+use Drupal\DrupalExtension\Hook\Call\EntityHook;
+use Drupal\DrupalExtension\Hook\Scope\EntityScope;
+
+class BeforeEntityCreate extends EntityHook
+{
+
+  /**
+   * Initializes hook.
+   */
+  public function __construct($filterString, $callable, $description = null) {
+    parent::__construct(EntityScope::BEFORE, $filterString, $callable, $description);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'BeforeEntityCreate';
+  }
+
+}

--- a/src/Behat/Hook/Call/BeforeEntityCreate.php
+++ b/src/Behat/Hook/Call/BeforeEntityCreate.php
@@ -1,17 +1,19 @@
 <?php
 
-
 namespace Metadrop\Behat\Hook\Call;
+
 use Drupal\DrupalExtension\Hook\Call\EntityHook;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
 
-class BeforeEntityCreate extends EntityHook
-{
+/**
+ * Hook before entity create.
+ */
+class BeforeEntityCreate extends EntityHook {
 
   /**
    * Initializes hook.
    */
-  public function __construct($filterString, $callable, $description = null) {
+  public function __construct($filterString, $callable, $description = NULL) {
     parent::__construct(EntityScope::BEFORE, $filterString, $callable, $description);
   }
 

--- a/src/Behat/Hook/Scope/AfterEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/AfterEntityCreateScope.php
@@ -3,7 +3,7 @@
 namespace Metadrop\Behat\Hook\Scope;
 
 /**
- * Scope after creating entities.
+ * Available scope after creating entities.
  */
 class AfterEntityCreateScope extends EntityScope {
 

--- a/src/Behat/Hook/Scope/AfterEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/AfterEntityCreateScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Metadrop\Behat\Hook\Scope;
+
+use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
+
+class AfterEntityCreateScope extends BaseEntityScope
+{
+  
+  public function getName()
+  {
+    return self::AFTER;
+  }
+
+}

--- a/src/Behat/Hook/Scope/AfterEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/AfterEntityCreateScope.php
@@ -2,12 +2,10 @@
 
 namespace Metadrop\Behat\Hook\Scope;
 
-use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
-
 /**
  * Scope after creating entities.
  */
-class AfterEntityCreateScope extends BaseEntityScope {
+class AfterEntityCreateScope extends EntityScope {
 
   /**
    * {@inheritdoc}

--- a/src/Behat/Hook/Scope/AfterEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/AfterEntityCreateScope.php
@@ -4,11 +4,15 @@ namespace Metadrop\Behat\Hook\Scope;
 
 use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
 
-class AfterEntityCreateScope extends BaseEntityScope
-{
-  
-  public function getName()
-  {
+/**
+ * Scope after creating entities.
+ */
+class AfterEntityCreateScope extends BaseEntityScope {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
     return self::AFTER;
   }
 

--- a/src/Behat/Hook/Scope/BeforeEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/BeforeEntityCreateScope.php
@@ -3,7 +3,7 @@
 namespace Metadrop\Behat\Hook\Scope;
 
 /**
- * Scope before creating entities.
+ * Available scope before creating entities.
  */
 class BeforeEntityCreateScope extends EntityScope {
 

--- a/src/Behat/Hook/Scope/BeforeEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/BeforeEntityCreateScope.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Metadrop\Behat\Hook\Scope;
+
+use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
+
+class BeforeEntityCreateScope extends EntityScope
+{
+  public function getName()
+  {
+    return self::BEFORE;
+  }
+
+}

--- a/src/Behat/Hook/Scope/BeforeEntityCreateScope.php
+++ b/src/Behat/Hook/Scope/BeforeEntityCreateScope.php
@@ -2,12 +2,15 @@
 
 namespace Metadrop\Behat\Hook\Scope;
 
-use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
+/**
+ * Scope before creating entities.
+ */
+class BeforeEntityCreateScope extends EntityScope {
 
-class BeforeEntityCreateScope extends EntityScope
-{
-  public function getName()
-  {
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
     return self::BEFORE;
   }
 

--- a/src/Behat/Hook/Scope/EntityScope.php
+++ b/src/Behat/Hook/Scope/EntityScope.php
@@ -5,10 +5,15 @@ namespace Metadrop\Behat\Hook\Scope;
 use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
 
 /**
- * Entity scope.
+ * Generic scope for entity hooks, that adds the entity type property.
  */
 abstract class EntityScope extends BaseEntityScope {
 
+  /**
+   * Entity type.
+   *
+   * @var string
+   */
   protected $entityType;
 
   /**

--- a/src/Behat/Hook/Scope/EntityScope.php
+++ b/src/Behat/Hook/Scope/EntityScope.php
@@ -4,8 +4,10 @@ namespace Metadrop\Behat\Hook\Scope;
 
 use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
 
-abstract class EntityScope extends BaseEntityScope
-{
+/**
+ * Entity scope.
+ */
+abstract class EntityScope extends BaseEntityScope {
 
   protected $entityType;
 
@@ -13,6 +15,7 @@ abstract class EntityScope extends BaseEntityScope
    * Get the entity type.
    *
    * @return mixed
+   *   Entity type.
    */
   public function getEntityType() {
     return $this->entityType;
@@ -22,6 +25,7 @@ abstract class EntityScope extends BaseEntityScope
    * Set the entity type.
    *
    * @param mixed $entityType
+   *   Entity type.
    */
   public function setEntityType($entityType) {
     $this->entityType = $entityType;

--- a/src/Behat/Hook/Scope/EntityScope.php
+++ b/src/Behat/Hook/Scope/EntityScope.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Metadrop\Behat\Hook\Scope;
+
+use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
+
+abstract class EntityScope extends BaseEntityScope
+{
+
+  protected $entityType;
+
+  /**
+   * Get the entity type.
+   *
+   * @return mixed
+   */
+  public function getEntityType() {
+    return $this->entityType;
+  }
+
+  /**
+   * Set the entity type.
+   *
+   * @param mixed $entityType
+   */
+  public function setEntityType($entityType) {
+    $this->entityType = $entityType;
+  }
+
+}


### PR DESCRIPTION
This pull request allow write steps to create any kind of drupal entity:

`@Given :entity_type entity:`

It is useful in the case you want create custom entities during tests so you don't need to create a special step for that. It can be repetitive, and a generic step reduce costs.
