### PR TITLE
Provide a way to initialize browser session in case it wasn't started yet.

### DIFF
--- a/src/Behat/MinkContextSessionTrait.php
+++ b/src/Behat/MinkContextSessionTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Metadrop\Behat;
+
+/**
+ * Trait to get a mink session previously initialized.
+ *
+ * Use this trait in the case you need session started before visiting the page.
+ */
+trait MinkContextSessionTrait {
+
+  /**
+   * Returns session.
+   *
+   * @param string|null $name name of the session OR active session will be used
+   *
+   * @return Session
+   */
+  public function getSession($name = null)
+  {
+    $session = parent::getSession($name);
+    if (!$session->isStarted()) {
+      $session->start();
+    }
+    return $session;
+  }
+
+}

--- a/src/Behat/MinkContextSessionTrait.php
+++ b/src/Behat/MinkContextSessionTrait.php
@@ -2,6 +2,8 @@
 
 namespace Metadrop\Behat;
 
+use Behat\Mink\Session;
+
 /**
  * Trait to get a mink session previously initialized.
  *
@@ -10,19 +12,16 @@ namespace Metadrop\Behat;
 trait MinkContextSessionTrait {
 
   /**
-   * Returns session.
+   * Asserts a sesson has been started.
    *
-   * @param string|null $name name of the session OR active session will be used
-   *
-   * @return Session
+   * @param Session $session
+   *   Mink session.
    */
-  public function getSession($name = null)
+  public function assertSessionStarted(Session $session)
   {
-    $session = parent::getSession($name);
     if (!$session->isStarted()) {
       $session->start();
     }
-    return $session;
   }
 
 }


### PR DESCRIPTION
Since behat/mink 1.7, the browser session is started only when a page is visited.
But there are some case where you want the session to be ready before the page si visited.
The most common use case is to resize the browser to another size different than default (s.e.: mobile portrait), in the @beforeScenario phase.

With the trait provided with this PR you could just call a method to ensure the session is started, before you execute the code that resizes your window. The session will only starts if it hasn't started yet.