### PR TITLE
Delete the generated entities by the EntityContext class.

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -263,7 +263,7 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
 
     $this->dispatchHooks('AfterEntityCreateScope', $entity, $entity_type);
 
-    $this->entities[$entity_type] = $entity_id;
+    $this->entities[$entity_type][] = $entity_id;
 
     return $entity_id;
   }

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -208,7 +208,7 @@ interface CoreInterface {
    * @param string $condition_operand
    *   Condition operand.
    */
-  public function deleteEntities($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE');
+  public function deleteEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE');
 
    /**
    * Delete entities by condition.
@@ -219,4 +219,15 @@ interface CoreInterface {
    *   Entity id.
    */
   public function entityDelete($entity_type, $entity_id);
+
+  /**
+   * Delete a list of entities of the same entity type.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param array $entities_ids
+   *   Entity id list.
+   */
+  public function entityDeleteMultiple($entity_type, array $entities_ids);
+
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -226,7 +226,7 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteEntities($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
+  public function deleteEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
     throw new PendingException('Pending to implement method in Drupal 7');
   }
 
@@ -235,6 +235,13 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
    */
   public function entityDelete($entity_type, $entity_id) {
     return entity_delete($entity_type, $entity_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityDeleteMultiple($entity_type, array $entities_ids) {
+    return entity_delete_multiple($entity_type, $entities_ids);
   }
 
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -308,7 +308,7 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     $condition_scaped = strtoupper($condition_operand) == 'LIKE' ? '%' . $database->escapeLike($condition_value) . '%' : $condition_value;
     $query->condition($condition_key, $condition_scaped, $condition_operand);
     $entities_ids = $query->execute();
-    $this->entityDelete($entities_ids);
+    $this->entityDeleteMultiple($entity_type, $entities_ids);
   }
 
   /**

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -275,12 +275,27 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteEntities($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
+  public function deleteEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
     $database = \Drupal::database();
     $query = \Drupal::entityQuery($entity_type);
     $condition_scaped = strtoupper($condition_operand) == 'LIKE' ? '%' . $database->escapeLike($condition_value) . '%' : $condition_value;
     $query->condition($condition_key, $condition_scaped, $condition_operand);
     $entities_ids = $query->execute();
+    $this->entityDelete($entities_ids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function entityDelete($entity_type, $entity_id) {
+    $controller = \Drupal::entityManager()->getStorage($entity_type);
+    $entity = $controller->load($entity_id);
+    $entity->delete();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function entityDeleteMultiple($entity_type, array $entities_ids) {
     $controller = \Drupal::entityManager()->getStorage($entity_type);
     $entities = $controller->loadMultiple($entities_ids);
     $controller->delete($entities);


### PR DESCRIPTION
The `Given :entity entity` step does not remove the generated entities after the scenario ends, like the given node, or given user contexts does.

This PR provides methods to delete every generated entity after the scenario.