### PR TITLE
Consider file field type as reference field on entity creation.

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -318,8 +318,12 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
 
     // Check if the field is an entity reference an allow values to be the
     // labels of the referenced entities.
+    $reference_types = [
+      'entity_reference',
+      'file',
+    ];
     foreach ($entity as $field_name => $field) {
-      if ($field->getFieldDefinition()->getType() === 'entity_reference') {
+      if (in_array($field->getFieldDefinition()->getType(), $reference_types)) {
         $value = $field->getString();
         if (is_numeric($value) === FALSE) {
           $referenced_entity_type = $field->getFieldDefinition()->getSetting('target_type');


### PR DESCRIPTION
When working on a project, I was trying to create a media entity referencing a file with the following code:

```gherkin
  Background:
    Given file with name "dummy.pdf"
    And users:
      | name         |
      | behat_test   |
    And "media" entity:
      | bundle       | field_private_file | revision_user | name        | status |
      | private_file | dummy.pdf         | behat_test     | behat_media | 1      |
```

But the code didn't create a reference from the media entity to the file entity, making the tests fail.

When debugging I found that the reason was that the `entityCreate` function only considers the fields of type "entity_reference" as references.

Fields of type "file" should be also included, as they hold references to file entities. The PR solves this.