### PR TITLE
Format string function is deprecated on drupal 8.

### DIFF
--- a/src/Behat/Context/LogsContext.php
+++ b/src/Behat/Context/LogsContext.php
@@ -69,7 +69,8 @@ class LogsContext extends RawDrupalContext {
     foreach ($logs as $log) {
       $log_variables = unserialize($log->variables);
       $log->variables = !empty($log_variables) ? $log_variables : [];
-      $message = mb_strimwidth(format_string($log->message, $log->variables), 0, 200, '...');
+      $formatted_string =  $this->getCore()->formatString($log->message, $log->variables);
+      $message = mb_strimwidth($formatted_string, 0, 200, '...');
       print "[{$log->type}] "
           . $message
           . " | Details: " . $this->getDblogEventUrl($log->wid) . "\n";

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -269,4 +269,17 @@ interface CoreInterface {
    */
   public function loadEntityByProperties(string $entity_type, array $properties);
 
+  /**
+   * Make string variable replacements.
+   *
+   * @param string $string
+   *   Message  with variables placeholders.
+   * @param array $params
+   *   List of variables replacements.
+   *
+   * @return string
+   *   Message with replacements.
+   */
+  public function formatString($string, array $params);
+
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -278,4 +278,11 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
     throw new PendingException('Pending to implement method in Drupal 7');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function formatString($string, array $params) {
+    return format_string($string, $params);
+  }
+
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -13,6 +13,7 @@ use Behat\Behat\Tester\Exception\PendingException;
 use Drupal\user\Entity\User;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Class Drupal8.
@@ -357,6 +358,14 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     }
 
     return $query->execute()->fetchAll();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formatString($string, array $params) {
+    $string = new FormattableMarkup($string, $params);
+    return $string;
   }
 
 }


### PR DESCRIPTION
Format string function is deprecated on drupal 8 so we replace with the
new way only on drupal 8 version and keep it on drupal 7.

See change record: https://www.drupal.org/node/2302363