### PR TITLE
Add a trait to handle Drupal state to use on FeatureContext classes

### DIFF
--- a/src/Behat/Context/StateContextTrait.php
+++ b/src/Behat/Context/StateContextTrait.php
@@ -2,6 +2,12 @@
 
 namespace Metadrop\Behat\Context;
 
+/**
+ * Trait to add to FeatureContext classes to create State changing steps.
+ *
+ * Use this trait in your FeatureContext class and use the setState to easily
+ * create custom steps that modify Drupal State values.
+ */
 trait StateContextTrait {
 
   /**

--- a/src/Behat/Context/StateContextTrait.php
+++ b/src/Behat/Context/StateContextTrait.php
@@ -39,8 +39,6 @@ trait StateContextTrait {
       $this->getCore()->stateSet($name, $value);
     }
     $this->state = [];
-
-     print "cleanState!!!221312!\n";
   }
 
   /**

--- a/src/Behat/Context/StateContextTrait.php
+++ b/src/Behat/Context/StateContextTrait.php
@@ -36,7 +36,7 @@ trait StateContextTrait {
   public function cleanState() {
     // Revert config that was changed.
     foreach ($this->state as $name => $value) {
-      $this->getCore()->stateSet($name, $value);
+      $this->getCore()->setState($name, $value);
     }
     $this->state = [];
   }
@@ -52,8 +52,8 @@ trait StateContextTrait {
    * @Given I set the state key :key to :value
    */
   public function setState($key, $value) {
-    $backup = $this->getCore()->stateGet($key);
-    $this->getCore()->stateSet($key, $value);
+    $backup = $this->getCore()->getState($key);
+    $this->getCore()->setState($key, $value);
     $this->state[$key] = $backup;
   }
 

--- a/src/Behat/Context/StateContextTrait.php
+++ b/src/Behat/Context/StateContextTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Metadrop\Behat\Context;
+
+trait StateContextTrait {
+
+  /**
+   * Keep track of any state that was changed so they can easily be reverted.
+   *
+   * @var array
+   */
+  protected $state = [];
+
+  /**
+   * Get active Drupal Driver.
+   *
+   * @return \Drupal\Driver\DrupalDriver
+   */
+  abstract public function getDriver($name = NULL);
+
+  /**
+   * Get current Drupal core.
+   *
+   * @return \NuvoleWeb\Drupal\Driver\Cores\CoreInterface|\Drupal\Driver\Cores\CoreInterface
+   *   Drupal core object instance.
+   */
+  public function getCore() {
+    return $this->getDriver()->getCore();
+  }
+
+  /**
+   * Revert any changed config.
+   *
+   * @AfterScenario
+   */
+  public function cleanState() {
+    // Revert config that was changed.
+    foreach ($this->state as $name => $value) {
+      $this->getCore()->stateSet($name, $value);
+    }
+    $this->state = [];
+
+     print "cleanState!!!221312!\n";
+  }
+
+  /**
+   * Sets a state item.
+   *
+   * @param string $key
+   *   The state key.
+   * @param mixed $value
+   *   Value to associate with identifier.
+   *
+   * @Given I set the state key :key to :value
+   */
+  public function setState($key, $value) {
+    $backup = $this->getCore()->stateGet($key);
+    $this->getCore()->stateSet($key, $value);
+    $this->state[$key] = $backup;
+  }
+
+}

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -8,6 +8,16 @@ namespace Metadrop\Behat\Cores;
 interface CoreInterface {
 
   /**
+   * {@inheritdoc}
+   */
+  public function getState($key);
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setState($key, $value);
+
+  /**
    * Clear page caches.
    *
    * @param string $path

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -8,12 +8,17 @@ namespace Metadrop\Behat\Cores;
 interface CoreInterface {
 
   /**
-   * {@inheritdoc}
+   * Gets a value from Drupal's State API.
+   *
+   * @param string $key
+   *   The key of the data to retrieve from State API.
    */
   public function getState($key);
 
   /**
-   * {@inheritdoc}
+   * Sets a value from Drupal's State API.
+   * @param string $key
+   * @param string  $value
    */
   public function setState($key, $value);
 

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -17,8 +17,11 @@ interface CoreInterface {
 
   /**
    * Sets a value from Drupal's State API.
+   *
    * @param string $key
-   * @param string  $value
+   *   The key of the data to store.
+   * @param mixed $value
+   *   The data to store.
    */
   public function setState($key, $value);
 

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -292,4 +292,18 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
     return format_string($string, $params);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function stateGet($key) {
+    throw new \Exception('State API does not exists in Drupal 7. This method is supported only in Drupal 8 or greater.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function stateSet($key, $value) {
+    throw new \Exception('State API does not exists in Drupal 7. This method is supported only in Drupal 8 or greater.');
+  }
+
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -295,14 +295,14 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function stateGet($key) {
+  public function getState($key) {
     throw new \Exception('State API does not exists in Drupal 7. This method is supported only in Drupal 8 or greater.');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function stateSet($key, $value) {
+  public function setState($key, $value) {
     throw new \Exception('State API does not exists in Drupal 7. This method is supported only in Drupal 8 or greater.');
   }
 

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -256,8 +256,8 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
    */
   public function getDbLogMessages(int $scenario_start_time, array $severities = [], array $types = []) {
     $query = db_select('watchdog', 'w')
-        ->fields('w', ['message', 'variables', 'type', 'wid'])
-        ->condition('timestamp', $scenario_start_time, '>=');
+      ->fields('w', ['message', 'variables', 'type', 'wid'])
+      ->condition('timestamp', $scenario_start_time, '>=');
 
     if (!empty($severities)) {
       $query->condition('severity', $severities, 'IN');
@@ -273,8 +273,7 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function loadEntityByLabel(string $entity_type, string $label)
-  {
+  public function loadEntityByLabel(string $entity_type, string $label) {
     throw new PendingException('Pending to implement method in Drupal 7');
   }
 

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -271,8 +271,8 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     if (!empty($directory) && strpos($directory, $private) !== FALSE) {
       $path = str_replace($private, '', $directory);
       $destination = \Drupal\Core\Url::fromRoute('system.private_file_download', ['filepath' => $path . '/' . $filename], [
-        'relative' => TRUE,
-      ])->toString();
+          'relative' => TRUE,
+        ])->toString();
     }
 
     return (!empty($destination)) ? $destination : NULL;
@@ -339,6 +339,7 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     $entity = $controller->load($entity_id);
     $entity->delete();
   }
+
   /**
    * {@inheritdoc}
    */
@@ -353,8 +354,8 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
    */
   public function getDbLogMessages(int $scenario_start_time, array $severities = [], array $types = []) {
     $query = \Drupal::database()->select('watchdog', 'w')
-        ->fields('w', ['message', 'variables', 'type', 'wid'])
-        ->condition('timestamp', $scenario_start_time, '>=');
+      ->fields('w', ['message', 'variables', 'type', 'wid'])
+      ->condition('timestamp', $scenario_start_time, '>=');
 
     if (!empty($severities)) {
       $query->condition('severity', $severities, 'IN');
@@ -388,4 +389,5 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   public function setState($key, $value) {
     \Drupal::state()->set($key, $value);
   }
+
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -375,4 +375,17 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     return $string;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function stateGet($key) {
+    return \Drupal::state()->get($key);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function stateSet($key, $value) {
+    \Drupal::state()->set($key, $value);
+  }
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -378,14 +378,14 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function stateGet($key) {
+  public function getState($key) {
     return \Drupal::state()->get($key);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function stateSet($key, $value) {
+  public function setState($key, $value) {
     \Drupal::state()->set($key, $value);
   }
 }


### PR DESCRIPTION
This comes from this https://github.com/Metadrop/behat-contexts/pull/62.

That PR creates a StateContext with a step like: 

`Given I set the state key "state_key_name" to "state_value"`

While is nice to be able to change Drupal State in Behat test, tests should be legible for humans. Using state keys and values is probably not legible. Also, most of the steps that need to change the state are probably very specific for one site.  So, we can create a PHP Trait with all the hard stuff to alter Drupal State, so any site can add it to its FeatureContext and create simple steps that use the API provided by the trait modifies the state.

For example, let's say we want to alter the key "my_obscure_key.obscure_propery" and set the "obscureValue" value.

WIth a StateContext it will be:

`Given I set the state key "my_obscure_key.obscure_propery" to "obscureValue"`

IMHO, this hard to read.

What about this?

```
class FeatureContext extends DrupalContext implements SnippetAcceptingContext {

  use Metadrop\Behat\Context\StateContextTrait;

 ...

    /**
     * @Given the functionality A is enabled
     */
    public function theFunctionalityAIsEnabled()
    {
      $this->setState("my_obscure_key.obscure_propery", "obscureValue");
    }
```

And in Gherkin you can use:

`Given the functionality A is enabled`

This way is very easy to create steps that are readable but handle Drupal State nicely

Thanks to @dlopez-akalam, from who I borrowed most of the code.


