### PR TITLE
Allows to disable honeypot time limit in order to perform automated form submissions

### DIFF
--- a/src/Behat/Context/AntiSpamContext.php
+++ b/src/Behat/Context/AntiSpamContext.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Metadrop\Behat\Context;
+
+use NuvoleWeb\Drupal\DrupalExtension\Context\RawMinkContext;
+
+class AntiSpamContext extends RawMinkContext {
+
+  /**
+   * The honeypot time limit
+   */
+  protected $honeypotTimeLimit;
+
+  /**
+   * Disable honeypot time limit value.
+   *
+   * To be used when the presence of a honeypot time limit is provoking
+   * false negatives on tests.
+   *
+   * @BeforeScenario @honeypot-disable
+   */
+  public function disableHoneypot() {
+    print('Honeypot: disabling time limit');
+    $this->honeypotTimeLimit = $this->getCore()->getHoneypotLimit();
+    $this->getCore()->setHoneypotLimit(0);
+  }
+
+  /**
+   * Restore honeypot time limit value.
+   *
+   * @AfterScenario @honeypot-disable
+   */
+  public function restoreHoneypot() {
+    print('Honeypot: restoring time limit');
+    $this->getCore()->setHoneypotLimit($this->honeypotTimeLimit);
+  }
+
+}

--- a/src/Behat/Context/FormContext.php
+++ b/src/Behat/Context/FormContext.php
@@ -7,6 +7,11 @@ use NuvoleWeb\Drupal\DrupalExtension\Context\RawMinkContext;
 class FormContext extends RawMinkContext {
 
   /**
+   * The honeypot time limit
+   */
+  protected $honeypotTimeLimit;
+
+  /**
    * Gets info about required state of a form element.
    *
    * It relies on the requeried class added to he element by Drupal. This
@@ -60,6 +65,30 @@ class FormContext extends RawMinkContext {
     if ($this->isFormElementRequired($type, $label)) {
       throw new \InvalidArgumentException("Form element \"$label\" of type \"$type\" is required");
     }
+  }
+
+  /**
+   * Disable honeypot time limit value.
+   *
+   * To be used when the presence of a honeypot time limit is provoking
+   * false negatives on tests.
+   *
+   * @BeforeScenario @honeypot-disable
+   */
+  public function disableHoneypot() {
+    print('Honeypot: disabling time limit');
+    $this->honeypotTimeLimit = \Drupal::configFactory()->getEditable('honeypot.settings')->get('time_limit');
+    \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', 0)->save();
+  }
+
+  /**
+   * Restore honeypot time limit value.
+   *
+   * @AfterScenario @honeypot-disable
+   */
+  public function restoreHoneypot() {
+    print('Honeypot: restoring time limit');
+    \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', $this->honeypotTimeLimit)->save();
   }
 
 }

--- a/src/Behat/Context/FormContext.php
+++ b/src/Behat/Context/FormContext.php
@@ -7,11 +7,6 @@ use NuvoleWeb\Drupal\DrupalExtension\Context\RawMinkContext;
 class FormContext extends RawMinkContext {
 
   /**
-   * The honeypot time limit
-   */
-  protected $honeypotTimeLimit;
-
-  /**
    * Gets info about required state of a form element.
    *
    * It relies on the requeried class added to he element by Drupal. This
@@ -65,30 +60,6 @@ class FormContext extends RawMinkContext {
     if ($this->isFormElementRequired($type, $label)) {
       throw new \InvalidArgumentException("Form element \"$label\" of type \"$type\" is required");
     }
-  }
-
-  /**
-   * Disable honeypot time limit value.
-   *
-   * To be used when the presence of a honeypot time limit is provoking
-   * false negatives on tests.
-   *
-   * @BeforeScenario @honeypot-disable
-   */
-  public function disableHoneypot() {
-    print('Honeypot: disabling time limit');
-    $this->honeypotTimeLimit = \Drupal::configFactory()->getEditable('honeypot.settings')->get('time_limit');
-    \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', 0)->save();
-  }
-
-  /**
-   * Restore honeypot time limit value.
-   *
-   * @AfterScenario @honeypot-disable
-   */
-  public function restoreHoneypot() {
-    print('Honeypot: restoring time limit');
-    \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', $this->honeypotTimeLimit)->save();
   }
 
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -327,4 +327,21 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
     return file_default_scheme() . '://';
   }
 
+  /**
+   * Gets the current Honeypot time limit
+   */
+  public function getHoneypotLimit() {
+    throw new PendingException('Pending to implement method in Drupal 7');
+  }
+
+  /**
+   * Sets the Honeypot time limit
+   *
+   * @param int $time_limit
+   *   The time limit to be set.
+   */
+  public function setHoneypotLimit(int $time_limit) {
+    throw new PendingException('Pending to implement method in Drupal 7');
+  }
+
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -424,4 +424,23 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
       ->get('default_scheme') . '://';
   }
 
+  /**
+   * Gets the current Honeypot time limit
+   *
+   * @return int
+   *   The time limit value
+   */
+  public function getHoneypotLimit(): int {
+    return \Drupal::configFactory()->getEditable('honeypot.settings')->get('time_limit');
+  }
+
+  /**
+   * Sets the Honeypot time limit
+   *
+   * @param int $time_limit
+   *   The time limit to be set.
+   */
+  public function setHoneypotLimit(int $time_limit): int {
+    \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', $time_limit)->save();
+  }
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -440,7 +440,7 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
    * @param int $time_limit
    *   The time limit to be set.
    */
-  public function setHoneypotLimit(int $time_limit): int {
+  public function setHoneypotLimit(int $time_limit) {
     \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', $time_limit)->save();
   }
 }


### PR DESCRIPTION
This PR adds a beforeScenario and afterScenario (using the tag honeypot-disable) that will deactivate the time limit during the test in order to allow form submissions without honeypot interference.