### PR TITLE
Ensure entities are cleaned on correct order and access check is bypassed

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -419,5 +419,10 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
         $this->getCore()->entityDelete($entity_item['entity_type'], $entity_item['entity_id']);
       }
     }
+
+    $this->entities = [];
+    $this->users = [];
+    $this->nodes = [];
   }
+
 }

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -361,19 +361,21 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
 
     if ($bypass_entities) {
       $entities = array_filter($this->entities, function($key) use ($bypass_entities){
-        return in_array($key, $bypass_entities);
+        return !in_array($key, $bypass_entities);
       }, ARRAY_FILTER_USE_KEY);
     }
     else {
       $entities = $this->entities;
     }
 
+    // Array reversion is needed in order to guarantee that any hierarchical
+    // relationship between entities (i.e: group and subgroup) is respected
+    // by removing first the later (dependent) entities.
     foreach (array_reverse($entities) as $entity_type => $ids) {
       foreach (array_reverse($ids) as $id) {
         $this->getCore()->entityDeleteMultiple($entity_type, [$id]);
       }
     }
   }
-
 
 }

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -375,7 +375,10 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
 
     $saved = $entity->save();
     $this->dispatchHooks('AfterEntityCreateScope', (object) (array) $entity, $entity_type);
-    $this->entities[$entity_type][] = $entity->id();
+    $this->entities[] = [
+      'entity_type' => $entity_type,
+      'entity_id' => $entity->id(),
+    ];
 
     return $saved;
   }

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -8,6 +8,8 @@ use Drupal\Core\Entity\Entity;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Driver\BlackboxDriver;
 use Drupal\Driver\Exception\UnsupportedDriverActionException;
+use Drupal\DrupalExtension\Hook\Scope\AfterNodeCreateScope;
+use Drupal\DrupalExtension\Hook\Scope\AfterUserCreateScope;
 use Symfony\Component\Serializer\Exception\UnsupportedException;
 
 /**
@@ -306,9 +308,11 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
    */
   protected function getGivenEntitiesMap(): array {
     $map = [];
+
     foreach($this->entities as $item) {
       $map[$item['entity_type']][] = $item['entity_id'];
     };
+
     $map['user'] = $this->users;
     $map['node'] = $this->nodes;
 
@@ -381,6 +385,22 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
     ];
 
     return $saved;
+  }
+
+  /**
+   * @afterNodeCreate
+   */
+  public function afterNodeCreate(AfterNodeCreateScope $scope) {
+    $node = $scope->getEntity();
+    $this->nodes[] = $node->nid;
+  }
+
+  /**
+   * @afterUserCreate
+   */
+  public function afterUserCreate(AfterUserCreateScope $scope) {
+    $user = $scope->getEntity();
+    $this->users[] = $user->uid;
   }
 
   /**

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -355,9 +355,23 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
   /**
    * @AfterScenario
    */
-  public function deleteGeneratedEntities() {
-    foreach ($this->entities as $entity_type => $ids) {
-      $this->getCore()->entityDeleteMultiple($entity_type, $ids);
+  public function cleanEntities() {
+
+    $bypass_entities = isset($this->customParameters['entities_clean_bypass']) ? $this->customParameters['entities_clean_bypass'] : FALSE;
+
+    if ($bypass_entities) {
+      $entities = array_filter($this->entities, function($key) use ($bypass_entities){
+        return in_array($key, $bypass_entities);
+      }, ARRAY_FILTER_USE_KEY);
+    }
+    else {
+      $entities = $this->entities;
+    }
+
+    foreach (array_reverse($entities) as $entity_type => $ids) {
+      foreach (array_reverse($ids) as $id) {
+        $this->getCore()->entityDeleteMultiple($entity_type, [$id]);
+      }
     }
   }
 

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -233,7 +233,7 @@ interface CoreInterface {
   public function getEntityTypes();
 
   /**
-   * Delete entities by condition.
+   * Get entities by condition.
    *
    * @param string $entity_type
    *   Entity type.
@@ -243,8 +243,11 @@ interface CoreInterface {
    *   Condition value.
    * @param string $condition_operand
    *   Condition operand.
+   *
+   * @return array
+   *   An array of entity ids.
    */
-  public function deleteEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE');
+  public function getEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE');
 
    /**
    * Delete entities by condition.

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -241,7 +241,7 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
+  public function getEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
     throw new PendingException('Pending to implement method in Drupal 7');
   }
 

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -338,16 +338,13 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
+  public function getEntitiesWithCondition($entity_type, $condition_key, $condition_value, $condition_operand = 'LIKE') {
     $database = \Drupal::database();
     $query = \Drupal::entityQuery($entity_type);
     $condition_scaped = strtoupper($condition_operand) == 'LIKE' ? '%' . $database->escapeLike($condition_value) . '%' : $condition_value;
     $query->condition($condition_key, $condition_scaped, $condition_operand);
     $query->accessCheck(FALSE);
-    $entities_ids = $query->execute();
-    foreach(array_reverse($entities_ids) as $id) {
-      $this->entityDeleteMultiple($entity_type, [$id]);
-    }
+    return $query->execute();
   }
 
   /**

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -343,8 +343,11 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     $query = \Drupal::entityQuery($entity_type);
     $condition_scaped = strtoupper($condition_operand) == 'LIKE' ? '%' . $database->escapeLike($condition_value) . '%' : $condition_value;
     $query->condition($condition_key, $condition_scaped, $condition_operand);
+    $query->accessCheck(FALSE);
     $entities_ids = $query->execute();
-    $this->entityDeleteMultiple($entity_type, $entities_ids);
+    foreach(array_reverse($entities_ids) as $id) {
+      $this->entityDeleteMultiple($entity_type, [$id]);
+    }
   }
 
   /**


### PR DESCRIPTION
This issue addresses two problems arised when deleting entities either on an @AfterScenario or by using @purgeEntities tag.

- Entities are deleted on the generation order (first in, first out). If there is any hierarchical relationship (for example, on the Group and Subgroup modules) it will cause errors as there are guards that prevent the parent removal if there are any child still present.
This PR uses array_reverse() in order to assure that the order is last in, first out.

- On purgeEntities, this PR adds an ->accessCheck(FALSE) because it defaults to true and might easily result on the entities not being purged.