### PR TITLE
Allow to define wether the entity cache should be reset prior to deletion

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -308,7 +308,7 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
       };
 
       foreach(array_reverse($entities_ids) as $id) {
-        $this->getCore()->entityDelete($entity_type, $id);
+        $this->getCore()->entityDelete($entity_type, $id, TRUE);
       }
     }
   }
@@ -429,7 +429,7 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
 
     foreach (array_reverse($this->entities) as $entity_item) {
       if (!in_array($entity_item['entity_type'], $bypass_entities)) {
-        $this->getCore()->entityDelete($entity_item['entity_type'], $entity_item['entity_id']);
+        $this->getCore()->entityDelete($entity_item['entity_type'], $entity_item['entity_id'], TRUE);
       }
     }
 

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -256,8 +256,10 @@ interface CoreInterface {
    *   Entity type.
    * @param int $id
    *   Entity id.
+   * @param bool $reset_cache
+   *   Wether the entity cache should be reset before loading it
    */
-  public function entityDelete($entity_type, $entity_id);
+  public function entityDelete($entity_type, $entity_id, $reset_cache = FALSE);
 
   /**
    * Obtain warnings and notices from watchdog logs.
@@ -278,8 +280,10 @@ interface CoreInterface {
    *   Entity type.
    * @param array $entities_ids
    *   Entity id list.
+   * @param bool $reset_cache
+   *   Wether the entity caches should be reset before loading them
    */
-  public function entityDeleteMultiple($entity_type, array $entities_ids);
+  public function entityDeleteMultiple($entity_type, array $entities_ids, $reset_cache = FALSE);
 
   /**
    * Load an entity with a specific label.

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -248,14 +248,14 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity_type, $entity_id) {
+  public function entityDelete($entity_type, $entity_id, $reset_cache = FALSE) {
     return entity_delete($entity_type, $entity_id);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function entityDeleteMultiple($entity_type, array $entities_ids) {
+  public function entityDeleteMultiple($entity_type, array $entities_ids, $reset_cache = FALSE) {
     return entity_delete_multiple($entity_type, $entities_ids);
   }
 

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -350,11 +350,16 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity_type, $entity_id) {
+  public function entityDelete($entity_type, $entity_id, $reset_cache = FALSE) {
     if ($entity_id instanceof EntityInterface) {
       $entity_id = $entity_id->id();
     }
     $controller = \Drupal::entityTypeManager()->getStorage($entity_type);
+
+    if ($reset_cache) {
+      $controller->resetCache([$entity_id]);
+    }
+
     $entity = $controller->load($entity_id);
     $entity->delete();
   }
@@ -362,9 +367,14 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityDeleteMultiple($entity_type, array $entities_ids) {
+  public function entityDeleteMultiple($entity_type, array $entities_ids, $reset_cache = FALSE) {
     $controller = \Drupal::entityTypeManager()->getStorage($entity_type);
     $entities = $controller->loadMultiple($entities_ids);
+
+    if ($reset_cache) {
+      $controller->resetCache($entities_ids);
+    }
+
     $controller->delete($entities);
   }
 


### PR DESCRIPTION
On some scenarios, the `entityDelete()` methods won't receive an updated version of the entity to delete (the entity could have been changed because, as part of the test, some values were implicit or explicitly changed).

This can lead to errors if there are some dependencies. In the case of Subgroup, the Group entity was cached and the values that reflect the hierarchy were missing when the deletion was triggered. This led to exceptions.

There is a new parameter ($reset_caches) that can be passed to entity deletion methods. This parameter will ensure that an up-to-date entity is deleted.