### PR TITLE
Add entity translation steps

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -117,6 +117,54 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
   }
 
   /**
+   * @Then the :entity_type with field :field_name and value :value translation :langcode should have the following values:
+   */
+  public function checkEntityTranslationValues($entity_type, $field_name, $value, $langcode, TableNode $values, $check_correct = TRUE) {
+    $entity = $this->getCore()->getEntityByField($entity_type, $field_name, $value);
+
+    // Check entity.
+    if (!isset($entity)) {
+      throw new \Exception('The ' . $entity_type . ' with ' . $field_name . ':  ' . $value . ' not found.');
+    }
+    if (!$entity->hasTranslation($langcode)) {
+      throw new \Exception('Entity does not have ' . $langcode . ' translation.');
+    }
+    $this->checkGivenEntityValues($entity->getTranslation($langcode), $values, $check_correct);
+  }
+
+  /**
+   * @Then the :entity_type with field :field_name and value :value translation :langcode should not have the following values:
+   */
+  public function checkEntityTranslationNotValues($entity_type, $field_name, $value, $langcode, TableNode $values) {
+    $this->checkEntityTranslationValues($entity_type, $field_name, $value, $langcode, $values, FALSE);
+  }
+
+  /**
+   * @Then the :entity_type with field :field_name and value :value should not have :langcode translation
+   */
+  public function checkEntityTranslationNotExists($entity_type, $field_name, $value, $langcode) {
+    $this->checkEntityTranslationExists($entity_type, $field_name, $value, $langcode, FALSE);
+  }
+
+  /**
+   * @Then the :entity_type with field :field_name and value :value should have :langcode translation
+   */
+  public function checkEntityTranslationExists($entity_type, $field_name, $value, $langcode, $check_exists = TRUE) {
+    $entity = $this->getCore()->getEntityByField($entity_type, $field_name, $value);
+
+    // Check entity.
+    if (!isset($entity)) {
+      throw new \Exception('The ' . $entity_type . ' with ' . $field_name . ':  ' . $value . ' not found.');
+    }
+    if ($check_exists && !$entity->hasTranslation($langcode)) {
+      throw new \Exception('Entity does not have ' . $langcode . ' translation and should.');
+    }
+    else if (!$check_exists && $entity->hasTranslation($langcode)) {
+      throw new \Exception('Entity does not have ' . $langcode . ' translation and should not.');
+    }
+  }
+
+  /**
    * Check object fields.
    *
    * @Then the :object_type with field :field_name and value :value should have the following values:
@@ -127,25 +175,38 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
    *  | behat@metadrop.net  | entity-replacement:user:mail:behat@metadrop.net:uid |
    */
   public function checkEntityTestValues($entity_type, $field_name, $value, TableNode $values, $throw_error_on_empty = TRUE) {
-    $hash = $values->getHash();
-    $fields = $hash[0];
-
     $entity = $this->getCore()->getEntityByField($entity_type, $field_name, $value);
 
     // Check entity.
     if (!isset($entity)) {
       throw new \Exception('The ' . $entity_type . ' with ' . $field_name . ':  ' . $value . ' not found.');
     }
+    $this->checkGivenEntityValues($entity, $values, $throw_error_on_empty);
+  }
+
+  /**
+   * Check given entity values.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity to check.
+   * @param \Behat\Gherkin\Node\TableNode $values
+   *   Values to evalate.
+   * @param bool $check_correct
+   *   Check correct or incorrect values.
+   */
+  protected function checkGivenEntityValues(EntityInterface $entity, TableNode $values, $check_correct = TRUE) {
+    $hash = $values->getHash();
+    $fields = $hash[0];
     // Make field tokens replacements.
     $fields = $this->replaceTokens($fields);
 
     // Check entity values and obtain the errors.
     $errors = $this->checkEntityValues($entity, $fields);
 
-    if ($throw_error_on_empty && !empty($errors)) {
+    if ($check_correct && !empty($errors)) {
       throw new \Exception('Failed checking values: ' . implode(', ', $errors));
     }
-    elseif (!$throw_error_on_empty && empty($errors)) {
+    elseif (!$check_correct && empty($errors)) {
       throw new \Exception('Entity values are correct, but it should not!');
     }
   }


### PR DESCRIPTION
To check when entity does have a translation:
- @Then the :entity_type with field :field_name and value :value should
have :langcode translation
- @Then the :entity_type with field :field_name and value :value should
not have :langcode translation

To check entity translation values:
- @Then the :entity_type with field :field_name and value :value
translation :langcode should have the following values:
- @Then the :entity_type with field :field_name and value :value
translation :langcode should not have the following values: