### PR TITLE
Add extra validation target_id in entityCreate

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -375,7 +375,7 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
       if (in_array($field->getFieldDefinition()->getType(), $reference_types) && !$field->getFieldDefinition()->isComputed()) {
         $values = $field->getValue();
         foreach ($values as $key => $value) {
-          if (is_array($value)) {
+          if (is_array($value)&& !empty($value['target_id'])) {
             $referenced_entity_type = $field->getFieldDefinition()->getSetting('target_type');
             $referenced_entity = $this->getCore()->loadEntityByLabel($referenced_entity_type, $value['target_id']);
             if ($referenced_entity instanceof EntityInterface) {

--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -375,7 +375,7 @@ class EntityContext extends RawDrupalContext implements SnippetAcceptingContext 
       if (in_array($field->getFieldDefinition()->getType(), $reference_types) && !$field->getFieldDefinition()->isComputed()) {
         $values = $field->getValue();
         foreach ($values as $key => $value) {
-          if (is_array($value)&& !empty($value['target_id'])) {
+          if (is_array($value) && !empty($value['target_id'])) {
             $referenced_entity_type = $field->getFieldDefinition()->getSetting('target_type');
             $referenced_entity = $this->getCore()->loadEntityByLabel($referenced_entity_type, $value['target_id']);
             if ($referenced_entity instanceof EntityInterface) {


### PR DESCRIPTION
When method entityCreate creates an entity with a referenced entity field without value, the process breaks.