### PR TITLE
User name is the owner of the group unsaved group

### DIFF
--- a/src/Behat/Context/DrupalGroupsExtendedContext.php
+++ b/src/Behat/Context/DrupalGroupsExtendedContext.php
@@ -105,6 +105,7 @@ class DrupalGroupsExtendedContext extends RawDrupalContext implements SnippetAcc
     /** @var \Drupal\group\Entity\Group $group */
     $group = $this->getEntityBylabel($group_type, $group_name);
     $group->setOwnerId($user->id());
+    $group->save();
   }
 
   /**


### PR DESCRIPTION
@Given the user :user_name is the owner of the group type :group_type with name :group_name step was setting correctly owner but with no effect due group is not saved.