### PR TITLE
MINK - Require a class that extends MinkContext instead of Drupal\DrupalExtension\Context\MinkContext

### DIFF
--- a/src/Behat/Context/I18nContext.php
+++ b/src/Behat/Context/I18nContext.php
@@ -8,6 +8,7 @@
 namespace Metadrop\Behat\Context;
 
 use Behat\Behat\Context\Context;
+use Behat\MinkExtension\Context\MinkContext;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Drupal\Core\Url;
@@ -34,7 +35,11 @@ class I18nContext extends RawMinkContext implements Context {
    */
   public function gatherContexts(BeforeScenarioScope $scope) {
     $environment = $scope->getEnvironment();
-    $this->minkContext = $environment->getContext('Drupal\DrupalExtension\Context\MinkContext');
+    foreach ($environment->getContexts() as $context) {
+      if ($context instanceof MinkContext) {
+        $this->minkContext = $context;
+      }
+    }
   }
 
   /**

--- a/src/Behat/Context/MediaContext.php
+++ b/src/Behat/Context/MediaContext.php
@@ -6,6 +6,7 @@ use Metadrop\Behat\Context\RawDrupalContext;
 use Metadrop\Behat\Context\UIContext;
 use Metadrop\Behat\Context\WaitingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\MinkContext;
 
 /**
  * Steps related with media.
@@ -43,7 +44,11 @@ class MediaContext extends RawDrupalContext {
    */
   public function gatherContexts(BeforeScenarioScope $scope) {
     $environment = $scope->getEnvironment();
-    $this->minkContext = $environment->getContext('Drupal\DrupalExtension\Context\MinkContext');
+    foreach ($environment->getContexts() as $context) {
+      if ($context instanceof MinkContext) {
+        $this->minkContext = $context;
+      }
+    }
     $this->uiContext = $environment->getContext(UIContext::class);
     $this->waitingContext = $environment->getContext(WaitingContext::class);
   }

--- a/src/Behat/Context/UsersRandomContext.php
+++ b/src/Behat/Context/UsersRandomContext.php
@@ -4,6 +4,7 @@ namespace Metadrop\Behat\Context;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\MinkContext;
 
 /**
  * Context used to generate random user data.
@@ -43,7 +44,11 @@ class UsersRandomContext extends RawDrupalContext {
    */
   public function gatherContexts(BeforeScenarioScope $scope) {
     $environment = $scope->getEnvironment();
-    $this->minkContext = $environment->getContext('Drupal\DrupalExtension\Context\MinkContext');
+    foreach ($environment->getContexts() as $context) {
+      if ($context instanceof MinkContext) {
+        $this->minkContext = $context;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

In the cases that it is needed to extend MinkContext (s.e.: trying to wrap a specific MinkContext step), there is an error saying that `Drupal\DrupalExtension\Context\MinkContext`does not exist. It happens because the specific Drupal extension's MinkContext class is required in some contexts:

- https://github.com/Metadrop/behat-contexts/blob/master/src/Behat/Context/I18nContext.php
- https://github.com/Metadrop/behat-contexts/blob/master/src/Behat/Context/MediaContext.php
- https://github.com/Metadrop/behat-contexts/blob/master/src/Behat/Context/UsersRandomContext.php

But looking deeply in the code, the context doesn't need to be an instance of  `Drupal\DrupalExtension\Context\MinkContext`, just an instance of `\Behat\MinkExtension\Context\MinkContext`.

## Steps to reproduce

Change the behat.yml class of 'Drupal\DrupalExtension\Context\MinkContext' by a class that extends `Drupal\DrupalExtension\Context\MinkContext`. The error will appear just before beginning the first scenario

## Solution

In the affected contexts, look for a context that is or extends `\Behat\MinkExtension\Context\MinkContext`. It will be safe enough knowing that there must only exist one instance of this class, as steps can't be duplicated among different contexts.