### PR TITLE
Deprecated function file_save_data()

### DIFF
--- a/src/Behat/Cores/Traits/FileTrait.php
+++ b/src/Behat/Cores/Traits/FileTrait.php
@@ -2,12 +2,17 @@
 
 namespace Metadrop\Behat\Cores\Traits;
 
-use Drupal\Core\File\FileSystemInterface;
-
 /**
  * Trait FileTrait.
  */
 trait FileTrait {
+
+  /**
+   * The string translation service.
+   *
+   * @var \Drupal\file\FileRepositoryInterface
+   */
+  protected $fileRepository;
 
   /**
    * Creates file in drupal.
@@ -32,7 +37,7 @@ trait FileTrait {
       $data = file_get_contents($file_path);
 
       // Existing files are replaced.
-      $file = file_save_data($data, $destination, 1);
+      $file = $this->getFileRepository()->writeData($data, $destination, 1);
       if (!$file) {
         throw new \Exception("Error: file could not be copied to directory");
       }
@@ -47,5 +52,19 @@ trait FileTrait {
    *   Default file scheme.
    */
   abstract public function getDefaultFileScheme();
+
+  /**
+   * Gets the file repository service.
+   *
+   * @return \Drupal\file\FileRepositoryInterface
+   *   The file repository service.
+   */
+  protected function getFileRepository() {
+    if (!$this->fileRepository) {
+      $this->fileRepository = \Drupal::service('file.repository');
+    }
+
+    return $this->fileRepository;
+  }
 
 }


### PR DESCRIPTION
Issue #147

I am working on a Drupal 10 project and when running Behat tests using a `metadrop/behat-context` step I get the following error:
`Fatal error: Call to undefined function Metadrop\Behat\Cores\Traits\file_save_data() (Behat\Testwork\Call\Exception\FatalThrowableError)`

As it appears in Drupal's documentation:
- This function is deprecated as of drupal:9.3.0 and is removed from drupal:10.0.0.
- Use \Drupal\file\FileRepositoryInterface::writeData instead.
https://api.drupal.org/api/drupal/core%21modules%21file%21file.module/function/file_save_data/9

I have made and tested the changes.
When I run the Behat test again with the changes applied it passed successfully.