### PR TITLE
Upload media independent of language

### DIFF
--- a/src/Behat/Context/MediaContext.php
+++ b/src/Behat/Context/MediaContext.php
@@ -77,7 +77,7 @@ class MediaContext extends RawDrupalContext {
     if ($widget == 'media_library') {
       $this->uiContext->iClickOnTheElementWithXpath("//input[contains(@id, 'edit-" . $field . "-open-button')]");
       $this->waitingContext->iWaitForAjaxToFinish(30);
-      $xpath = "//*[@id='drupal-modal']//label[contains(text(),'". $media_title ."')]/following-sibling::input";
+      $xpath = "//div[contains(@class, 'views-field-media-library-select-form')]//div[contains(@class, 'form-type--checkbox')]/label[contains(text(),'". $media_title ."')]/following-sibling::input";
       $this->iSelectMedia($widget, $xpath);
     }
   }

--- a/src/Behat/Context/MediaContext.php
+++ b/src/Behat/Context/MediaContext.php
@@ -77,7 +77,7 @@ class MediaContext extends RawDrupalContext {
     if ($widget == 'media_library') {
       $this->uiContext->iClickOnTheElementWithXpath("//input[contains(@id, 'edit-" . $field . "-open-button')]");
       $this->waitingContext->iWaitForAjaxToFinish(30);
-      $xpath = "//*[@id='drupal-modal']//label[text()='Select " . $media_title . "']/following-sibling::input";
+      $xpath = "//*[@id='drupal-modal']//label[contains(text(),'". $media_title ."')]/following-sibling::input";
       $this->iSelectMedia($widget, $xpath);
     }
   }


### PR DESCRIPTION
Currently, the media upload step contains the string "Select " which makes the step incompatible if you are not using English on the website.

I have added and checked a correction to be able to upload media independently of the language of the site where Behat tests are being launched.