### PR TITLE
Remove dirname to get the right path

### DIFF
--- a/src/Behat/Context/LogsContext.php
+++ b/src/Behat/Context/LogsContext.php
@@ -201,7 +201,7 @@ class LogsContext extends RawDrupalContext {
    */
   public static function writeReport(array $grouped_logs) {
     // Add date to report.
-    $source_dir = dirname(static::$path);
+    $source_dir = static::$path;
     $date = date_create();
     $time = date_format($date, "Y-m-d-H-i-s");
     $source_file = $source_dir . '/dblog-report-' . $time . '.csv';

--- a/src/Behat/Context/LogsContext.php
+++ b/src/Behat/Context/LogsContext.php
@@ -206,7 +206,7 @@ class LogsContext extends RawDrupalContext {
     $time = date_format($date, "Y-m-d-H-i-s");
     $source_file = $source_dir . '/dblog-report-' . $time . '.csv';
     if (!file_exists($source_dir)) {
-      mkdir($source_dir, 0664, TRUE);
+      mkdir($source_dir, 0777, TRUE);
     }
     if (is_writable($source_dir)) {
       // Open CSV.


### PR DESCRIPTION
Remove dirname to get the right path.
Jenkins is failing because the wrong path /job/..../job/tests/job/PR-183/10/consoleFull
```
Error when executing always post condition:
java.io.IOException: .../reports/behat/dblog does not exist.
```

```
Created dblog report on /var/www/html/docroot/../reports/behat/report_dblog-2023-03-21-11-14-41.csv
```

And this is because the dirname function removes the last part of the path. Dirname was mandatory when the path included the report file name, but now it should be removed to get the right dirname.