### PR TITLE
COOKIES - After accept check if the banner is null or not visible

### DIFF
--- a/src/Behat/Context/CookieComplianceContext.php
+++ b/src/Behat/Context/CookieComplianceContext.php
@@ -143,7 +143,10 @@ class CookieComplianceContext extends RawMinkContext {
         sleep(1);
       }
       $agree_button->press();
-      if (!$this->getSession()->wait(10000, sprintf('document.querySelector("%s") == null', $this->cookieBannerSelector))) {
+      if (!$this->getSession()->wait(
+        10000,
+        sprintf('document.querySelector("%s") == null || document.querySelector("%s").style.visibility == "hidden"',
+          $this->cookieBannerSelector, $this->cookieBannerSelector))) {
         throw new \Exception(sprintf('The cookie banner with selector "%s" is stil present after accepting cookies.', $this->cookieBannerSelector));
       }
     }


### PR DESCRIPTION
After accepting the cookie banner, we should check if the banner is null or not visible.

In the case of OneTrust, the banner is set to display none and visibility: hidden instead of deleting the banner, so the current step does not work in those cases.

As a solution, we can check if the banner is present but also check the visibility of the element.

There are a lot of solutions on JS to check if an element is visible and maybe this one is not the best, but for this case, seems to work.

Other solutions are listed here https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom

If we decide on a more accurate solution, please add it to the PR.
