### PR TITLE
Parse str expects string, null given

### DIFF
--- a/src/Behat/Context/UrlContext.php
+++ b/src/Behat/Context/UrlContext.php
@@ -13,8 +13,9 @@ class UrlContext extends RawMinkContext {
    */
   public function urlShouldHaveParamWithValue($param, $value, $have = TRUE) {
     $url = $this->getSession()->getCurrentUrl();
+    $url_query = parse_url($url, PHP_URL_QUERY) ?? '';
     $queries = [];
-    parse_str(parse_url($url, PHP_URL_QUERY), $queries);
+    parse_str($url_query, $queries);
     if (!(isset($queries[$param]) && $queries[$param] == $value) && $have) {
       throw new \Exception("The param " . $param . " with value " . $value . " is not in the url");
     }


### PR DESCRIPTION
When the URL query is not set, then parse_url returns a null, parse_str expects a string, and if a null is given, then an error is thrown.

```
    And current url should not have the "s" param with "ar" value
      8192: parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/metadrop/behat-contexts/src/Behat/Context/UrlContext.php line 17
```

Because the Context also checks when a param is not set when any query params are empty are also valid.