### PR TITLE
Remove dependency with "Metadrop/drupal-behat" fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,6 @@
             "email": "hi@metadrop.net"
         }
     ],
-    "repositories": [
-      {
-        "type": "vcs",
-        "url": "https://github.com/Metadrop/drupal-behat.git"
-      }
-    ],
     "require": {
       "nuvoleweb/drupal-behat": "^1.2",
       "symfony/console": "^4 || ^5 || ^6"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-      "nuvoleweb/drupal-behat": "^1.2",
+      "nuvoleweb/drupal-behat": "^1.3",
       "symfony/console": "^4 || ^5 || ^6"
     },
     "autoload": {


### PR DESCRIPTION
The original repository has been updated with the changes introduced by the Metadrop fork, so the dependency is removed.

https://github.com/nuvoleweb/drupal-behat