### PR TITLE
Standardize and refactor the way entity urls are being visited in contexts

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -70,10 +70,7 @@ class EntityContext extends RawDrupalContext {
     }
 
     $entity = $this->getCore()->entityLoadSingle($entity_type, $last_entity);
-    $path = $this->getCore()->buildEntityUri($entity_type, $entity, $subpath);
-    if (!empty($path)) {
-      $this->getSession()->visit($this->locatePath($path));
-    }
+    $this->visitEntityPath($entity_type, $entity, $subpath);
   }
 
   /**
@@ -86,15 +83,7 @@ class EntityContext extends RawDrupalContext {
    */
   public function goToTheEntityWithLabel($entity_type, $label, $subpath = NULL, $language = NULL) {
     $entity = $this->getCore()->loadEntityByLabel($entity_type, $label);
-    $path = $this->getCore()->buildEntityUri($entity_type, $entity, $subpath);
-
-    if ($language) {
-      $prefix = $this->getCore()->getLanguagePrefix($language);
-      $path = $prefix . '/' . $path;
-    }
-    if (!empty($path)) {
-      $this->getSession()->visit($this->locatePath($path));
-    }
+    $this->visitEntityPath($entity_type, $entity, $subpath, $language);
   }
 
   /**
@@ -110,13 +99,28 @@ class EntityContext extends RawDrupalContext {
       $properties_filter[$property_name] = $property_value;
     }
     $entity = $this->getCore()->loadEntityByProperties($entity_type, $properties_filter);
-    $path = $this->getCore()->buildEntityUri($entity_type, $entity, $subpath);
+    $this->visitEntityPath($entity_type, $entity, $subpath, $language);
+  }
 
-    if ($language) {
-      $prefix = $this->getCore()->getLanguagePrefix($language);
-      $path = $prefix . '/' . $path;
-    }
-    if (!empty($path)) {
+  /**
+   * Visit a path of a specific entity.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param mixed $entity
+   *   Entity.
+   * @param string|NULL $subpath
+   *   Subpath.
+   * @param $language
+   *   Language.
+   */
+  protected function visitEntityPath(string $entity_type, $entity, string $subpath = NULL, $language = NULL) {
+    $path_found = $this->getCore()->buildEntityUri($entity_type, $entity, $subpath);
+    if (!empty($path_found)) {
+      $path = $this->getCore()->buildPath(
+        '/' . $path_found,
+        $language,
+      );
       $this->visitPath($path);
     }
     else {

--- a/src/Behat/Cores/CoreInterface.php
+++ b/src/Behat/Cores/CoreInterface.php
@@ -382,4 +382,22 @@ interface CoreInterface {
    */
   public function getLanguagePrefix($language);
 
+  /**
+   * Builds URL string given an internal path and a langcode.
+   *
+   * It is needed to build a URL without knowing the specific
+   * language detection the site has. Typically language detection
+   * is done by language prefix, but in some cases other specific
+   * logics are used.
+   *
+   * @param string $path
+   *   Drupal internal path.
+   * @param string|NULL $langcode
+   *   Langcode, if needed.
+   *
+   * @return string
+   *   Relative path accesible by browser.
+   */
+  public function buildPath(string $path, string $langcode = NULL);
+
 }

--- a/src/Behat/Cores/Drupal7.php
+++ b/src/Behat/Cores/Drupal7.php
@@ -385,4 +385,15 @@ class Drupal7 extends OriginalDrupal7 implements CoreInterface {
     return file_save_data($data, $destination, $replace);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildPath(string $path, string $langcode = NULL) {
+    if (!empty($langcode)) {
+      $prefix = $this->getLanguagePrefix($langcode);
+      return $prefix . '/' . $path;
+    }
+    return $path;
+  }
+
 }

--- a/src/Behat/Cores/Drupal8.php
+++ b/src/Behat/Cores/Drupal8.php
@@ -579,4 +579,22 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
     return $this->getFileRepository()->writeData($data, $destination, $replace);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildPath(string $path, string $langcode = NULL) {
+    $url_parameters = [];
+    if (!empty($langcode)) {
+      $language_manager = \Drupal::languageManager();
+      $language = $language_manager->getLanguage($langcode);
+      if (!$language instanceof LanguageInterface) {
+        throw new \InvalidArgumentException(sprintf("Language %s not found", $langcode));
+      }
+      $url_parameters['language'] = $language;
+    }
+
+    $url = Url::fromUserInput($path, $url_parameters);
+    return $url->toString();
+  }
+
 }


### PR DESCRIPTION
- All methods that visit entities use the same method
- Now the relative path is generated using Drupal\Core\Url class so code is not dependent of language detection method