### PR TITLE
Added Context property to avoid dynamic creation of iframe property

### DIFF
--- a/src/Behat/Context/UIContext.php
+++ b/src/Behat/Context/UIContext.php
@@ -33,6 +33,14 @@ class UIContext extends RawMinkContext {
    */
   protected $waitingContext;
 
+    
+  /**
+   * The iframe to switch to.
+   *
+   * @var string
+   */
+  protected $iframe;
+
   /**
    * Constructor.
    *


### PR DESCRIPTION
On behat text, when I try to interact with an iframe, I get this warning:
![image](https://github.com/Metadrop/behat-contexts/assets/4212917/d9578aa5-baa4-4d77-a2b0-b01d7b1ea14a)

The test works, but this warnings tag the test as failed. The Context property iframe must be declared.