### PR TITLE
Added VideoRecordingContext class to add info screen when recording tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,3 +336,25 @@ Then the url should match "/example-page"
 #### Configuration
 
 No configuration needed.
+
+### Video Recording Context
+
+This context helps with video recording of Behat scenarios by displaying scenario metadata in the browser before each test. It is useful for identifying tests in video recordings.
+
+#### Functionality
+
+- Optionally displays a green screen for a configurable duration before each scenario, to help segment videos.
+- Optionally displays an info screen with the feature description, scenario name, background steps, and scenario steps, for a configurable duration.
+- All options are configurable via context parameters.
+
+#### Configuration
+
+Add `VideoRecordingContext` to your suite in `behat.yml`:
+
+```yaml
+- Metadrop\Behat\Context\VideoRecordingContext:
+    parameters:
+      show_test_info_screen: true
+      show_test_info_screen_time: 2000
+      show_green_screen: false
+      show_green_screen_time: 0

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -30,7 +30,12 @@ default:
         - Metadrop\Behat\Context\UsersContext
         - Metadrop\Behat\Context\UsersRandomContext
         - Metadrop\Behat\Context\WaitingContext
-
+        - Metadrop\Behat\Context\VideoRecordingContext:
+            parameters:
+              show_test_info_screen: true
+              show_test_info_screen_time: 2000
+              show_green_screen: false
+              show_green_screen_time: 0
      filters:
         tags: "~@exclude"
   extensions:

--- a/src/Behat/Context/VideoRecordingContext.php
+++ b/src/Behat/Context/VideoRecordingContext.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @file
+ *
+ * Video Recording Context for Behat.
+ *
+ */
+
+namespace Metadrop\Behat\Context;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use NuvoleWeb\Drupal\DrupalExtension\Context\RawMinkContext;
+
+
+/**
+ * Context to show test info before tests to record it.
+ *
+ * This context provides functionality to record videos of test scenarios.
+ * It can be configured to record videos for all scenarios or only for failed ones.
+ *
+ * Context params:
+ *   'show_test_info_screen': If true, shows an screen with tests info and steps.
+ *   'show_test_info_screen_time': How many ms must the info screen be shown.
+ *   'show_green_screen': If true, shows a green screen before the test.
+ *   'show_green_screen_time': How many ms must the green screen be shown.
+ *
+ * @package Metadrop\Behat\Context
+ */
+class VideoRecordingContext extends RawMinkContext {
+
+  /**
+   * Context parameters.
+   *
+   * @var array
+   */
+  protected $customParameters;
+
+  /**
+   * Constructor.
+   *
+   * Save class params, if any.
+   *
+   * @param array $parameters
+   *   The definition parameters.
+   */
+  public function __construct($parameters = []) {
+    // Default values.
+    $defaults = [
+      'show_test_info_screen' => TRUE,
+      'show_test_info_screen_time' => 2000,
+      'show_green_screen' => FALSE,
+      'show_green_screen_time' => 3000,
+    ];
+
+    // Collect received parameters.
+    $this->customParameters = [];
+    if (!empty($parameters)) {
+      // Filter any invalid parameters.
+      $this->customParameters = array_intersect_key($parameters, $defaults);
+    }
+
+    // Apply default values.
+    $this->customParameters += $defaults;
+  }
+
+  /**
+   * Show tests name and green screen.
+   *
+   * @BeforeScenario @javascript
+   *
+   * @param BeforeScenarioScope $scope
+   *    Scenary scope.
+   */
+  public function showScenarioDataBeforeTest(BeforeScenarioScope $scope) {
+    // Show green screen.
+    if ($this->customParameters['show_green_screen']) {
+      // Build green split page
+      $this->getSession()->visit('about:blank');
+      $this->getSession()->executeScript("
+        document.documentElement.style.background = '#00ff00';
+        document.body.style.background = '#00ff00';
+      ");
+      $this->getSession()->wait($this->customParameters['show_green_screen_time']);
+    }
+
+    // Show test info screen.
+    if ($this->customParameters['show_test_info_screen']) {
+      // Get the scenario and feature info.
+      $scenario = $scope->getScenario();
+      $feature = $scope->getFeature();
+      $feature_description = $feature->getDescription() ?? '';
+      $scenario_name = $scenario->getTitle() ?? '';
+      $steps = $scenario->getSteps();
+
+      $steps_texts = [];
+      foreach ($steps as $step) {
+        $steps_texts[] = $step->getText();
+      }
+      $steps_string = implode('<br>', $steps_texts);
+
+      $background_steps = [];
+      $background = $feature->getBackground();
+      if ($background) {
+        foreach ($background->getSteps() as $step) {
+          $background_steps[] = $step->getText();
+        }
+      }
+      $background_steps = implode('<br>', $background_steps);
+
+      // Build HTML content
+      $html = '<h1>' . htmlspecialchars($feature_description) . '</h1>';
+      $html .= '<h2>' . htmlspecialchars($scenario_name) . '</h2>';
+      if ($background_steps) {
+        $html .= '<h3>Background:</h3><p>' . $background_steps . '</p>';
+      }
+      $html .= '<h3>Steps:</h3><p>' . $steps_string . '</p>';
+
+      // Build debug page
+      $this->getSession()->visit('about:blank');
+      $this->getSession()->executeScript("document.documentElement.innerHTML= "
+        . json_encode($html) . ";");
+      $this->getSession()->wait($this->customParameters['show_test_info_screen_time']);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the VideoRecordingContext class to display scenario metadata (name, description, steps, and background) before each Behat test, making identification in video recordings easier. It allows configuration of a green screen and/or info screen display, as well as their durations, via parameters. Uses Behat hooks and Mink sessions to manipulate the browser before each scenario.