### PR TITLE
Required "webmozart/path-util": "^2.0" as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
       "nuvoleweb/drupal-behat": "^1.3",
+      "webmozart/path-util": "^2.0",
       "symfony/console": ">= 4"
     },
     "autoload": {


### PR DESCRIPTION
Hi, I have some requirements running Behat for Drupal 11.
Running test, I need this dependency: "webmozart/path-util": "^2.0", but when I downloaded using -W, it's not getting installed.
I guess that can be setted in the composer dependencies.
Thanks in advance.

NOTE: "metadrop/behat-contexts": "^1.3", === 1.20.3 version.