### PR TITLE
Nodes and users created on EntityContext, must be stored as array

### DIFF
--- a/src/Behat/Context/EntityContext.php
+++ b/src/Behat/Context/EntityContext.php
@@ -474,8 +474,12 @@ class EntityContext extends RawDrupalContext {
       $map[$item['entity_type']][] = $item['entity_id'];
     };
 
-    $map['user'] = $this->users;
-    $map['node'] = $this->nodes;
+    $map['user'] = array_map(function ($user) {
+      return $user->uid;
+    }, $this->users);
+    $map['node'] = array_map(function ($node) {
+      return $node->nid;
+    }, $this->nodes);
 
     return $map;
   }


### PR DESCRIPTION
EntityContext must keep the same structure as the parent class for the nodes and users arrays, storing the object with nid, type, etc., not only the id. This throw a warning:

> Warning: Attempt to read property "nid" on string in vendor/drupal/drupal-driver/src/Drupal/Driver/Cores/Drupal8.php line 114

This PR fixes the structure of the arrays, removing this warning. In the future, it is advisable to review whether EntityContext.php really needs to keep track of nodes and users, as the parent class already takes care of those entity types.
